### PR TITLE
Adding extra Crossref fields

### DIFF
--- a/joss.00011/10.21105.joss.00011.crossref.xml
+++ b/joss.00011/10.21105.joss.00011.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>48ffa453203cc919fa2da7360e2f94ff</doi_batch_id>
-    <timestamp>20171024063540</timestamp>
+    <doi_batch_id>9a06112480460412f64c608d54b02a71</doi_batch_id>
+    <timestamp>20171024134907</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>11</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.47798</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/11</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00011</item_number>
+          <identifier id_type="doi">10.21105/joss.00011</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.47798</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/11</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00011</doi>
-          <timestamp>20171024063540</timestamp>
+          <timestamp>20171024134907</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00011</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00011/10.21105.joss.00011.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Cranmer, Kyle and Pavez, Juan and Louppe, Gilles, Approximating Likelihood Ratios with Calibrated Discriminative  Classifiers, arxiv, 2, http://arxiv.org/abs/1506.02169v2, http://arxiv.org/abs/1506.02169v2, 2016-03-18</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00012/10.21105.joss.00012.crossref.xml
+++ b/joss.00012/10.21105.joss.00012.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f0b86c9652603cbca2eada4c87a0f34c</doi_batch_id>
-    <timestamp>20171023214329</timestamp>
+    <doi_batch_id>e77f5502b2dde26e3438651fd6c0127e</doi_batch_id>
+    <timestamp>20171024134908</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>12</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.50995</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/12</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00012</item_number>
+          <identifier id_type="doi">10.21105/joss.00012</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.50995</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/12</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00012</doi>
-          <timestamp>20171023214329</timestamp>
+          <timestamp>20171024134908</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00012</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00012/10.21105.joss.00012.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Scikit-learn: Machine learning in Python, Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and others, The Journal of Machine Learning Research, 12, 2825–2830, 2011, JMLR. org</unstructured_citation></citation><citation key="ref2"><unstructured_citation>API design for machine learning software: experiences from the scikit-learn project, Buitinck, Lars and Louppe, Gilles and Blondel, Mathieu and Pedregosa, Fabian and Mueller, Andreas and Grisel, Olivier and Niculae, Vlad and Prettenhofer, Peter and Gramfort, Alexandre and Grobler, Jaques and others, arXiv preprint arXiv:1309.0238, 2013</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Statistics, Data Mining, and Machine Learning in Astronomy: A Practical Python Guide for the Analysis of Survey Data, Ivezić, Željko and Connolly, Andrew J and VanderPlas, Jacob T and Gray, Alexander, 2014, Princeton University Press</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Jones, Eric and Oliphant, Travis and Peterson, Pearu and others, SciPy: Open source scientific tools for Python, 2001–, http://www.scipy.org/, [Online; accessed 2016-05-04]</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00016/10.21105.joss.00016.crossref.xml
+++ b/joss.00016/10.21105.joss.00016.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>685181810087be7d5e6685dbafaae84a</doi_batch_id>
-    <timestamp>20171023214338</timestamp>
+    <doi_batch_id>6e6b53bcc8c390b0585540259717c063</doi_batch_id>
+    <timestamp>20171024134910</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>16</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.51096</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/16</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00016</item_number>
+          <identifier id_type="doi">10.21105/joss.00016</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.51096</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/16</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00016</doi>
-          <timestamp>20171023214338</timestamp>
+          <timestamp>20171024134910</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00016</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00016/10.21105.joss.00016.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1007/lrca-2015-3</doi></citation><citation key="ref2"><doi>10.1016/0022-0396(89)90142-3</doi></citation><citation key="ref3"><doi>10.1103/PhysRevLett.89.114501</doi></citation></citation_list>
       </journal_article>

--- a/joss.00017/10.21105.joss.00017.crossref.xml
+++ b/joss.00017/10.21105.joss.00017.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>142b5cefeae312843d4b3b377494432e</doi_batch_id>
-    <timestamp>20171023214350</timestamp>
+    <doi_batch_id>4ce5d1e117a9e47f5dbb0731c468c167</doi_batch_id>
+    <timestamp>20171024134911</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>17</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.13750</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/17</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00017</item_number>
+          <identifier id_type="doi">10.21105/joss.00017</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.13750</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/17</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00017</doi>
-          <timestamp>20171023214350</timestamp>
+          <timestamp>20171024134911</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00017</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00017/10.21105.joss.00017.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/SERVICES.2007.63</doi></citation><citation key="ref2"><doi>10.1109/MC.2009.365</doi></citation><citation key="ref3"><doi>10.1016/j.parco.2011.05.005</doi></citation><citation key="ref4"><doi>10.1155/2005/128026</doi></citation><citation key="ref5"><doi>10.1007/978-3-540-28642-4_2</doi></citation><citation key="ref6"><unstructured_citation>Integrating Abstractions to Enhance the Execution of Distributed Applications, Turilli, Matteo and Zhang, Zhao and Merzky, Andre and Wilde, Michael and Weissman, Jon and Katz, Daniel S and Jha, Shantenu and others, arXiv preprint arXiv:1504.04720, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00018/10.21105.joss.00018.crossref.xml
+++ b/joss.00018/10.21105.joss.00018.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>bc3a8ac62bf9dbf0433d9d4fccf8f9ae</doi_batch_id>
-    <timestamp>20171023214359</timestamp>
+    <doi_batch_id>7b6bc82aff7da1b08683d2e6df055ecb</doi_batch_id>
+    <timestamp>20171024134912</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>18</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.51798</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/18</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00018</item_number>
+          <identifier id_type="doi">10.21105/joss.00018</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.51798</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/18</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00018</doi>
-          <timestamp>20171023214359</timestamp>
+          <timestamp>20171024134912</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00018</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00018/10.21105.joss.00018.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1038/nmeth.3317</doi></citation><citation key="ref2"><doi>10.1038/nmeth.1923</doi></citation><citation key="ref3"><doi>10.1371/journal.pone.0074432</doi></citation></citation_list>
       </journal_article>

--- a/joss.00020/10.21105.joss.00020.crossref.xml
+++ b/joss.00020/10.21105.joss.00020.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e7afd461df6463952354cd7caec7d7e5</doi_batch_id>
-    <timestamp>20171023214409</timestamp>
+    <doi_batch_id>f3e1652b0aef1b86b38fdc48175b177e</doi_batch_id>
+    <timestamp>20171024134913</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>20</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.53186</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/20</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00020</item_number>
+          <identifier id_type="doi">10.21105/joss.00020</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.53186</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/20</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00020</doi>
-          <timestamp>20171023214409</timestamp>
+          <timestamp>20171024134913</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00020</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00020/10.21105.joss.00020.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><doi>10.1038/nmeth.3252</doi></citation><citation key="ref3"><doi>10.1371/journal.pcbi.1003118</doi></citation><citation key="ref4"><unstructured_citation>SummarizedExperiment: SummarizedExperiment container, Morgan, Martin and Obenchain, Valerie and Hester, Jim and Pagès, Hervé, 2016, R package version 1.3.1</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00021/10.21105.joss.00021.crossref.xml
+++ b/joss.00021/10.21105.joss.00021.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ca1d335851e28b41457ad09430a3d8e9</doi_batch_id>
-    <timestamp>20171023214418</timestamp>
+    <doi_batch_id>bafff93d5ef6cbedf0107cc28a9d368b</doi_batch_id>
+    <timestamp>20171024134915</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>21</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.51622</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/21</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00021</item_number>
+          <identifier id_type="doi">10.21105/joss.00021</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.51622</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/21</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00021</doi>
-          <timestamp>20171023214418</timestamp>
+          <timestamp>20171024134915</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00021</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00021/10.21105.joss.00021.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The Unicode Consortium, The Unicode Consortium. Unicode Collation Algorithm (Unicode Technical Standard #10), 2015, http://unicode.org/reports/tr10/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00023/10.21105.joss.00023.crossref.xml
+++ b/joss.00023/10.21105.joss.00023.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ebdffdcc6e7e72f6443b6c9f69dd195a</doi_batch_id>
-    <timestamp>20171023214427</timestamp>
+    <doi_batch_id>a2e772bf6ee732f4e45aa54174f6c744</doi_batch_id>
+    <timestamp>20171024134916</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>23</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.51556</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/23</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00023</item_number>
+          <identifier id_type="doi">10.21105/joss.00023</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.51556</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/23</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00023</doi>
-          <timestamp>20171023214427</timestamp>
+          <timestamp>20171024134916</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00023</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00023/10.21105.joss.00023.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The OWL API, http://owlapi.sourceforge.net/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>OWL 2 web ontology language manchester syntax, Horridge, Matthew and Patel-Schneider, Peter F, 2009, https://www.w3.org/TR/owl2-manchester-syntax/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>OWL 2 web ontology language: Structural specification and functional-style syntax, Motik, Boris and Patel-Schneider, Peter F and Parsia, Bijan and Bock, Conrad and Fokoue, Achille and Haase, Peter and Hoekstra, Rinke and Horrocks, Ian and Ruttenberg, Alan and Sattler, Uli, 2009, https://www.w3.org/TR/owl2-syntax/</unstructured_citation></citation><citation key="ref4"><unstructured_citation>OWL 2 Web Ontology Language Document Overview, W3C OWL Working Group, 2009, https://www.w3.org/TR/owl2-overview/</unstructured_citation></citation><citation key="ref5"><doi>10.1038/nbt1346</doi></citation></citation_list>
       </journal_article>

--- a/joss.00024/10.21105.joss.00024.crossref.xml
+++ b/joss.00024/10.21105.joss.00024.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>26e8c284e73bcc10c60796fa00f1efd8</doi_batch_id>
-    <timestamp>20171023214437</timestamp>
+    <doi_batch_id>47123cc8d53d91579abdeb4b7878a7f8</doi_batch_id>
+    <timestamp>20171024134917</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>24</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.53155</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/24</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00024</item_number>
+          <identifier id_type="doi">10.21105/joss.00024</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.53155</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/24</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00024</doi>
-          <timestamp>20171023214437</timestamp>
+          <timestamp>20171024134917</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00024</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00024/10.21105.joss.00024.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref2"><unstructured_citation>Foreman-Mackey, Daniel, corner.py on GitHub, 2016, https://github.com/dfm/corner.py, 2016-05-26</unstructured_citation></citation><citation key="ref3"><doi>10.5281/zenodo.53155</doi></citation></citation_list>
       </journal_article>

--- a/joss.00025/10.21105.joss.00025.crossref.xml
+++ b/joss.00025/10.21105.joss.00025.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>bf9f4464eec2b8fe8fa51c649287d7eb</doi_batch_id>
-    <timestamp>20171023214446</timestamp>
+    <doi_batch_id>2f3a801076d4f4bd246b6aced0a38a52</doi_batch_id>
+    <timestamp>20171024134918</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>25</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.53740</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/25</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00025</item_number>
+          <identifier id_type="doi">10.21105/joss.00025</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.53740</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/25</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00025</doi>
-          <timestamp>20171023214446</timestamp>
+          <timestamp>20171024134918</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00025</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00025/10.21105.joss.00025.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1186/1471-2105-9-559</doi></citation><citation key="ref2"><doi>10.1038/ncomms10464</doi></citation><citation key="ref3"><doi>10.1038/nmeth.1681</doi></citation><citation key="ref4"><doi>10.1093/bioinformatics/btq565</doi></citation></citation_list>
       </journal_article>

--- a/joss.00026/10.21105.joss.00026.crossref.xml
+++ b/joss.00026/10.21105.joss.00026.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a98d822cd8dbfbae5cbbf4600efe5d4c</doi_batch_id>
-    <timestamp>20171023214455</timestamp>
+    <doi_batch_id>f5603d95ddc81ea3cc326a04dcf2db14</doi_batch_id>
+    <timestamp>20171024134919</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>26</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.55251</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/26</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00026</item_number>
+          <identifier id_type="doi">10.21105/joss.00026</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.55251</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/26</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00026</doi>
-          <timestamp>20171023214455</timestamp>
+          <timestamp>20171024134919</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00026</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00026/10.21105.joss.00026.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Abrahams, David and Gurtovoy, Aleksey, C++ Template Metaprogramming: Concepts, Tools, and Techniques from Boost and Beyond, Addison-Wesley Professional, 2004, 978-0321227256</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Curtin, Ryan R. and Cline, James R. and Slagle, N. P. and March, William B. and Ram, Parikshit and Mehta, Nishant A. and Gray, Alexander G., MLPACK: A Scalable C++ Machine Learning Library, Journal of Machine Learning Research, 14, Mar, 2013, 801–805, http://jmlr.org/papers/v14/curtin13a.html</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Demmel, James W., Applied Numerical Linear Algebra, SIAM, 1997, 978-0898713893</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Eaton, John W. and Bateman, David and Hauberg, Søren and Wehbring, Rik, GNU Octave version 4.0.0 manual: a high-level interactive language for numerical computations, 2015, http://www.gnu.org/software/octave/</unstructured_citation></citation><citation key="ref5"><doi>10.1016/j.csda.2013.02.005</doi></citation><citation key="ref6"><unstructured_citation>Intel, Math Kernel Library (MKL), 2016, \urlhttp://software.intel.com/en-us/intel-mkl/</unstructured_citation></citation><citation key="ref7"><unstructured_citation>NVIDIA, NVBLAS Library, 2015, \urlhttp://docs.nvidia.com/cuda/nvblas/</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Sanderson, Conrad, Armadillo: An Open Source C++ Linear Algebra Library for Fast Prototyping and Computationally Intensive Experiments, NICTA, 2010</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Xianyi, Zhang and Qian, Wang and Saar, Werner, OpenBLAS: An optimized BLAS library, 2016, \urlhttp://www.openblas.net/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00027/10.21105.joss.00027.crossref.xml
+++ b/joss.00027/10.21105.joss.00027.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>4db8b15a92c3dd49d9969ff8980ddb4d</doi_batch_id>
-    <timestamp>20171023214503</timestamp>
+    <doi_batch_id>72dfee976336134982b3bdaf9ab0b57c</doi_batch_id>
+    <timestamp>20171024134920</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>27</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.153989</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/27</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00027</item_number>
+          <identifier id_type="doi">10.21105/joss.00027</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.153989</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/27</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00027</doi>
-          <timestamp>20171023214503</timestamp>
+          <timestamp>20171024134920</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00027</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00027/10.21105.joss.00027.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1101/029827</doi></citation></citation_list>
       </journal_article>

--- a/joss.00028/10.21105.joss.00028.crossref.xml
+++ b/joss.00028/10.21105.joss.00028.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>585f144fe4d7941fb4b5bb14db0abc97</doi_batch_id>
-    <timestamp>20171023214512</timestamp>
+    <doi_batch_id>6e298c2e0c47c078475eeef387f50d55</doi_batch_id>
+    <timestamp>20171024134921</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>28</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.55663</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/28</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00028</item_number>
+          <identifier id_type="doi">10.21105/joss.00028</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.55663</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/28</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00028</doi>
-          <timestamp>20171023214512</timestamp>
+          <timestamp>20171024134921</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00028</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00028/10.21105.joss.00028.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1098/rstb.2010.0162</doi></citation><citation key="ref2"><unstructured_citation>Holland, Barbara R and Huber, K T and Dress, A and Moulton, V, Molecular Biology and Evolution, 12, 2051–2059, [delta] Plots: A tool for analyzing phylogenetic distance data, 19, 2002, http://mbe.oxfordjournals.org/content/19/12/2051.full</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Maddison, D R and Swofford, D L and Maddison, Wayne P., Systematic Biology, 4, 590–621, Nexus: An extensible file format for systematic information, 46, 1997</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00029/10.21105.joss.00029.crossref.xml
+++ b/joss.00029/10.21105.joss.00029.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f49bb4c77db32be129bc24f888d91f10</doi_batch_id>
-    <timestamp>20171023214522</timestamp>
+    <doi_batch_id>865b4e600215e6b56c3e226b7504fe54</doi_batch_id>
+    <timestamp>20171024134922</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>29</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3443750.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/29</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00029</item_number>
+          <identifier id_type="doi">10.21105/joss.00029</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3443750.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/29</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00029</doi>
-          <timestamp>20171023214522</timestamp>
+          <timestamp>20171024134922</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00029</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00029/10.21105.joss.00029.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Pro Git, Chacon, S. and Straub, B., Apress, 2014, 2nd</unstructured_citation></citation><citation key="ref2"><doi>10.5334/jors.bj</doi></citation><citation key="ref3"><unstructured_citation>Science as an open enterprise: Open data for open science, Royal Society, jun, 2012, 6</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Guidance on best practice in the management of research data, Research Council UK, jul, 2015, 7</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Technical Committee ISO/TC 46 (Information and documentation), Subcommittee SC 9 (Identification and description), ISO 26324:2012 Information and documentation – Digital object identifier system, International Organisation for Standardization, 2012</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00031/10.21105.joss.00031.crossref.xml
+++ b/joss.00031/10.21105.joss.00031.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e6b12c26b3463c7b16e17753253139bc</doi_batch_id>
-    <timestamp>20171023214530</timestamp>
+    <doi_batch_id>dadd7c118d6bc06df8cf2269ad634712</doi_batch_id>
+    <timestamp>20171024134923</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>31</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.56821</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/31</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00031</item_number>
+          <identifier id_type="doi">10.21105/joss.00031</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.56821</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/31</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00031</doi>
-          <timestamp>20171023214530</timestamp>
+          <timestamp>20171024134923</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00031</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00031/10.21105.joss.00031.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1080/03610927508827223</doi></citation><citation key="ref2"><unstructured_citation>Nonparametric simple regression: Smoothing scatterplots, Fox, J, 2000, Sage</unstructured_citation></citation><citation key="ref3"><unstructured_citation>2000, 652–658, Tipping, M E, The relevance vector machine, Advances in Neural Information Processing Systems (NIPS)</unstructured_citation></citation><citation key="ref4"><unstructured_citation>2001, 1, 211–244, Tipping, M E, Sparse Bayesian learning and the relevance vector machine, Journal of Machine Learning Research</unstructured_citation></citation><citation key="ref5"><unstructured_citation>2003, Tipping, M E and Faul, A C, Fast marginal likelihood maximisation for sparse Bayesian models, Proceedings of the Ninth International Workshop on Artificial Intelligence and Statistics (AISTATS)</unstructured_citation></citation><citation key="ref6"><doi>10.1038/nn1008</doi></citation><citation key="ref7"><doi>10.1093/cercor/bhs231</doi></citation><citation key="ref8"><doi>10.1016/j.neuroimage.2016.04.029</doi></citation><citation key="ref9"><doi>10.1016/j.neuroimage.2010.01.061</doi></citation><citation key="ref10"><doi>10.1016/j.neurobiolaging.2013.04.006</doi></citation></citation_list>
       </journal_article>

--- a/joss.00032/10.21105.joss.00032.crossref.xml
+++ b/joss.00032/10.21105.joss.00032.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a7092e25b7c337b6095cf7b9ba9cf8a3</doi_batch_id>
-    <timestamp>20171023214539</timestamp>
+    <doi_batch_id>eb9aa659fed75b292bb33dca6b26a065</doi_batch_id>
+    <timestamp>20171024134924</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>32</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.59896</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/32</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00032</item_number>
+          <identifier id_type="doi">10.21105/joss.00032</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.59896</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/32</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00032</doi>
-          <timestamp>20171023214539</timestamp>
+          <timestamp>20171024134924</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00032</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00032/10.21105.joss.00032.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Čučković, Zoran, Exploring intervisibility networks: a case study from Bronze and Iron Age Istria (Croatia and Slovenia)., CAA 2014 - 21st Century Archaeology : Proceedings of the 42nd Annual Conference on Computer Applications and Quantitative Methods in Archaeology, 2015, Giligny, François and Djindjian, François and Costa, Laurent and Moscati, Paola and Robert, Sandrine, 469 - 478., Archaeopress, Paris, France</unstructured_citation></citation><citation key="ref2"><unstructured_citation>ERDAS, ERDAS Imagine Suite 2015, Hexagon Geospatial, Norcross, 2015</unstructured_citation></citation><citation key="ref3"><unstructured_citation>ESRI, ArcGis Desktop: Release 10.4, Environmental Systems Research Institute., 2016, Redlands</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Higuchi, Tadahiko, Visual and Spatial Structure of Landscapes., MIT Press, 1983, Cambridge, Mass.</unstructured_citation></citation><citation key="ref5"><doi>10.1080/713811741</doi></citation><citation key="ref6"><doi>http://dx.doi.org/10.1016/j.envsoft.2011.11.014</doi></citation></citation_list>
       </journal_article>

--- a/joss.00033/10.21105.joss.00033.crossref.xml
+++ b/joss.00033/10.21105.joss.00033.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a784142b0338a54fca690dc17fb78201</doi_batch_id>
-    <timestamp>20171023214548</timestamp>
+    <doi_batch_id>377d903b3eb0777e761da57c97fcb253</doi_batch_id>
+    <timestamp>20171024134926</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>33</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.58851</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/33</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00033</item_number>
+          <identifier id_type="doi">10.21105/joss.00033</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.58851</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/33</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00033</doi>
-          <timestamp>20171023214548</timestamp>
+          <timestamp>20171024134926</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00033</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00033/10.21105.joss.00033.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1111/j.1745-3992.2011.00223.x</doi></citation><citation key="ref2"><unstructured_citation>Madnani, Nitin and Loukina, Anastassia, RSMTool, 2016, https://github.com/EducationalTestingService/rsmtool, 2016-06-23</unstructured_citation></citation><citation key="ref3"><doi>10.5281/zenodo.12825</doi></citation><citation key="ref4"><unstructured_citation>Denver, Colorado, Loukina, Anastassia and Zechner, Klaus and Chen, Lei and Heilman, Michael, Proceedings of the Tenth Workshop on Innovative Use of NLP for Building Educational Applications, 12–19, Feature selection for automated speech scoring, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00034/10.21105.joss.00034.crossref.xml
+++ b/joss.00034/10.21105.joss.00034.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>224227df234d0310e9e9e35dd26bbe86</doi_batch_id>
-    <timestamp>20171023214556</timestamp>
+    <doi_batch_id>d67e0780cb98055a04f73d7f479a85ef</doi_batch_id>
+    <timestamp>20171024134927</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>34</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.61670</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/34</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00034</item_number>
+          <identifier id_type="doi">10.21105/joss.00034</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.61670</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/34</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00034</doi>
-          <timestamp>20171023214556</timestamp>
+          <timestamp>20171024134927</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00034</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00034/10.21105.joss.00034.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1023/A:1008306431147</doi></citation><citation key="ref2"><unstructured_citation>Scikit-learn: Machine Learning in Python, Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V. and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P. and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E., Journal of Machine Learning Research, 12, 2825–2830, 2011</unstructured_citation></citation><citation key="ref3"><unstructured_citation>GPy, GPy: A Gaussian process framework in python, \urlhttp://github.com/SheffieldML/GPy, 2012</unstructured_citation></citation><citation key="ref4"><unstructured_citation>JMLR Workshop and Conference Proceedings, Yamins, Daniel and Tax, David and Bergstra, James S., http://jmlr.csail.mit.edu/proceedings/papers/v28/bergstra13.pdf, Making a Science of Model Search: Hyperparameter Optimization in Hundreds of Dimensions for Vision Architectures, 1, 28, Dasgupta, Sanjoy and Mcallester, David, 2013, Proceedings of the 30th International Conference on Machine Learning (ICML-13), 115-123</unstructured_citation></citation><citation key="ref5"><doi>10.5281/zenodo.48545</doi></citation><citation key="ref6"><doi>10.5281/zenodo.56251</doi></citation></citation_list>
       </journal_article>

--- a/joss.00035/10.21105.joss.00035.crossref.xml
+++ b/joss.00035/10.21105.joss.00035.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>87222acf04183762c4c98298b612b118</doi_batch_id>
-    <timestamp>20171023214605</timestamp>
+    <doi_batch_id>4b589ac10df0076edf7fd5c8f4f6c76a</doi_batch_id>
+    <timestamp>20171024134928</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>35</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.160256</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/35</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00035</item_number>
+          <identifier id_type="doi">10.21105/joss.00035</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.160256</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/35</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00035</doi>
-          <timestamp>20171023214605</timestamp>
+          <timestamp>20171024134928</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00035</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00035/10.21105.joss.00035.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Omorfi—Free and open source morphological lexical database for Finnish, Pirinen, Tommi A, Proceedings of the 20th Nordic Conference of Computational Linguistics, NODALIDA 2015, May 11-13, 2015, Vilnius, Lithuania, 109, 313–315, 2015, Linköping University Electronic Press</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Lindén, Krister and Axelson, Erik and Drobac, Senka and Hardwick, Sam and Kuokkala, Juha and Niemi, Jyrki and Pirinen, Tommi and Silfverberg, Miikka, Mahlow, Cerstin and Piotrowski, Michael, Systems and Frameworks for Computational Morphology, HFST – A System for Creating NLP Tools, Springer, 2013, Computer Science, 380, Communications in Computer and Information Science, Berlin Heidelberg, 53–71</unstructured_citation></citation><citation key="ref3"><doi>10.1007/s10579-013-9244-1</doi></citation><citation key="ref4"><unstructured_citation>Mäkelä, Eetu and Lindquist, Thea and Hyvönen, Eero, CORE - A Contextual Reader based on Linked Data, Proceedings of Digital Humanities 2016, long papers, 2016, jul, Kraków, Poland, 7</unstructured_citation></citation><citation key="ref5"><doi>10.1045/july2016-paakkonen</doi></citation><citation key="ref6"><doi>10.1007/978-3-319-11955-7_60</doi></citation><citation key="ref7"><unstructured_citation>Open-Source Infrastructures for Collaborative Work on Under-Resourced Languages, Moshagen, Sjur and Rueter, Jack and Pirinen, Tommi and Trosterud, Trond and Tyers, Francis M, Proceedings of the Ninth International Conference on Language Resources and Evaluation, LREC, 71–77</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00036/10.21105.joss.00036.crossref.xml
+++ b/joss.00036/10.21105.joss.00036.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b33102bc26a71dd2607c3b0d3317ddd0</doi_batch_id>
-    <timestamp>20171023214616</timestamp>
+    <doi_batch_id>01664744d2c55a4f474217f982154bdc</doi_batch_id>
+    <timestamp>20171024134929</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>36</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.57495</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/36</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00036</item_number>
+          <identifier id_type="doi">10.21105/joss.00036</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.57495</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/36</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00036</doi>
-          <timestamp>20171023214616</timestamp>
+          <timestamp>20171024134929</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00036</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00036/10.21105.joss.00036.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1111/j.1467-9531.2006.00176.x</doi></citation><citation key="ref2"><doi>10.1016/j.socnet.2006.08.005</doi></citation></citation_list>
       </journal_article>

--- a/joss.00037/10.21105.joss.00037.crossref.xml
+++ b/joss.00037/10.21105.joss.00037.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>676d033f21352e0d09e88ac145baf3a2</doi_batch_id>
-    <timestamp>20171023214625</timestamp>
+    <doi_batch_id>6d9b943e800a150b521660e6d1b92070</doi_batch_id>
+    <timestamp>20171024134930</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>37</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.56714</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/37</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00037</item_number>
+          <identifier id_type="doi">10.21105/joss.00037</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.56714</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/37</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00037</doi>
-          <timestamp>20171023214625</timestamp>
+          <timestamp>20171024134930</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00037</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00037/10.21105.joss.00037.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.56714</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>dplyr: A Grammar of Data Manipulation, Wickham, Hadley and Francois, Romain and RStudio, 2015, R package version 0.4.3, https://CRAN.R-project.org/package=dplyr</unstructured_citation></citation><citation key="ref4"><unstructured_citation>ggplot2: An Implementation of the Grammar of Graphics, Wickham, Hadley and Chang, Winston and RStudio, 2016, R package version 2.1.0, https://CRAN.R-project.org/package=ggplot2</unstructured_citation></citation><citation key="ref5"><unstructured_citation>broom: Convert Statistical Analysis Objects into Tidy Data Frames, Robinson, David and Gomez, Matthieu and Demeshev, Boris and Menne, Dieter and Nutter, Benjamin and Johnston, Luke and Bolker, Ben and Briatte, Francois and Wickham, Hadley, 2015, R package version 0.4.0, https://CRAN.R-project.org/package=broom</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Text Mining Infrastructure in R, Ingo Feinerer, Kurt Hornik and Meyer, David, 2008, Journal of Statistical Software, 25, 5, 1-54, http://www.jstatsoft.org/v25/i05/</unstructured_citation></citation><citation key="ref7"><unstructured_citation>quanteda: Quantitative Analysis of Textual Data, Benoit, Kenneth and Nulty, Paul, 2016, R package version 0.9.4, https://CRAN.R-project.org/package=quanteda</unstructured_citation></citation><citation key="ref8"><doi>10.18637/jss.v059.i10</doi></citation></citation_list>
       </journal_article>

--- a/joss.00038/10.21105.joss.00038.crossref.xml
+++ b/joss.00038/10.21105.joss.00038.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>04b503a762c91891d26b1ad6ab6e15c3</doi_batch_id>
-    <timestamp>20171023214633</timestamp>
+    <doi_batch_id>aea9493252f2fd214353d3a9f1512ad9</doi_batch_id>
+    <timestamp>20171024134931</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>38</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.4239665.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/38</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00038</item_number>
+          <identifier id_type="doi">10.21105/joss.00038</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.4239665.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/38</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00038</doi>
-          <timestamp>20171023214633</timestamp>
+          <timestamp>20171024134931</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00038</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00038/10.21105.joss.00038.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>SPDX, SPDX.org, 2016, https://SPDX.org, 2016-10-10</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Germonprez, Matt and Gurney, Thomas and Shankar Korlimarla, Sai Uday and Gandhi, Robin, DoSOCSv2: A System for SPDX 2.0 Document Creation and Storage, 2016, https://github.com/DoSOCSv2/DoSOCSv2, 2016-00-10</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00040/10.21105.joss.00040.crossref.xml
+++ b/joss.00040/10.21105.joss.00040.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>eaf0df6feade2c55ebca2f250ee26851</doi_batch_id>
-    <timestamp>20171023214642</timestamp>
+    <doi_batch_id>2064b258617c24664f23e48c12f8b880</doi_batch_id>
+    <timestamp>20171024134932</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>40</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.59387</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/40</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00040</item_number>
+          <identifier id_type="doi">10.21105/joss.00040</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.59387</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/40</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00040</doi>
-          <timestamp>20171023214642</timestamp>
+          <timestamp>20171024134932</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00040</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00040/10.21105.joss.00040.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>New York, Csikszentmihalyi, Mihaly and Abuhamdeh, Sami and Nakamura, Jeanne, Handbook of competence and motivation, Elliot, Andrew J. and Dweck, Carol S., 1-59385-123-5, 598–608, Guilford Publications, Inc., Flow, 2005</unstructured_citation></citation><citation key="ref2"><unstructured_citation>San Francisco, Larson, Reed and Csikszentmihalyi, Mihaly, New Directions for Methodology of Social and Behavioral Sciences, Reis, Harry. T., 41–56, Jossey-Bass, The Experience Sampling Method, 1983</unstructured_citation></citation><citation key="ref3"><doi>10.1145/2544114.2544130</doi></citation><citation key="ref4"><doi>10.5281/zenodo.59382</doi></citation><citation key="ref5"><doi>10.1145/1247660.1247670</doi></citation><citation key="ref6"><doi>10.1007/s00779-011-0465-2</doi></citation><citation key="ref7"><unstructured_citation>metricwire, Breakthrough Research, 2016, http://metricwire.com/, 2016-08-03</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Medtronic, Zephyr, 2016, http://www.zephyranywhere.com/, 2016-07-18</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Göttingen, Rheinberg, Falko and Vollmeyer, Regina and Engeser, Stefan, Diagnostik von Motivation und Selbstkonzept, Stiensmeier-Pelster, Joachim and Rheinberg, Falko, 978-3-8017-1674-5, 261–279, Hogrefe Verlag, Die Erfassung des Flow-Erlebens, 2003</unstructured_citation></citation><citation key="ref10"><unstructured_citation>Amsterdam, Bogutzky, Simon and Grüter, Barbara and Roque, Licinio and Hajinejad, Nassrin, Abstractbook of the 7th European conference on positive psychology, 56–57, Analysis of‚flow while walking and running: psychophysiological correlates and activity-based results, 2014</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00041/10.21105.joss.00041.crossref.xml
+++ b/joss.00041/10.21105.joss.00041.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a834644540932b5b7c61d5a1f9042071</doi_batch_id>
-    <timestamp>20171023214651</timestamp>
+    <doi_batch_id>4cc946304b059f398c703a43b2a93f71</doi_batch_id>
+    <timestamp>20171024134933</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>41</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.23671</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/41</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00041</item_number>
+          <identifier id_type="doi">10.21105/joss.00041</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.23671</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/41</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00041</doi>
-          <timestamp>20171023214651</timestamp>
+          <timestamp>20171024134933</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00041</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00041/10.21105.joss.00041.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>New York, Csikszentmihalyi, Mihaly and Abuhamdeh, Sami and Nakamura, Jeanne, Handbook of competence and motivation, Elliot, Andrew J. and Dweck, Carol S., 1-59385-123-5, 598–608, Guilford Publications, Inc., Flow, 2005</unstructured_citation></citation><citation key="ref2"><unstructured_citation>San Francisco, Larson, Reed and Csikszentmihalyi, Mihaly, New Directions for Methodology of Social and Behavioral Sciences, Reis, Harry. T., 41–56, Jossey-Bass, The Experience Sampling Method, 1983</unstructured_citation></citation><citation key="ref3"><doi>10.1145/2544114.2544130</doi></citation><citation key="ref4"><doi>10.5281/zenodo.59382</doi></citation><citation key="ref5"><doi>10.5281/zenodo.59382</doi></citation><citation key="ref6"><unstructured_citation>Göttingen, Rheinberg, Falko and Vollmeyer, Regina and Engeser, Stefan, Diagnostik von Motivation und Selbstkonzept, Stiensmeier-Pelster, Joachim and Rheinberg, Falko, 978-3-8017-1674-5, 261–279, Hogrefe Verlag, Die Erfassung des Flow-Erlebens, 2003</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Hreljac, Alan, 0966-6362, Gait & posture, 3, 199–206, Stride smoothness evaluation of runners and other athletes., 11, 2000</unstructured_citation></citation><citation key="ref8"><doi>10.7600/jpfsm.3.11</doi></citation><citation key="ref9"><doi>10.1016/j.cmpb.2013.07.024</doi></citation></citation_list>
       </journal_article>

--- a/joss.00042/10.21105.joss.00042.crossref.xml
+++ b/joss.00042/10.21105.joss.00042.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d6782438033952c6e086559e36263501</doi_batch_id>
-    <timestamp>20171023214700</timestamp>
+    <doi_batch_id>071b036bbc5ad9839010b268f68e7a3f</doi_batch_id>
+    <timestamp>20171024134935</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>42</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.59127</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/42</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00042</item_number>
+          <identifier id_type="doi">10.21105/joss.00042</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.59127</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/42</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00042</doi>
-          <timestamp>20171023214700</timestamp>
+          <timestamp>20171024134935</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00042</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00042/10.21105.joss.00042.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.2307/1990339</doi></citation><citation key="ref2"><unstructured_citation>Gillespie.jl: Stochastic simulation in Julia, Frost, Simon D.W., https://github.com/sdwfrost/Gillespie.jl, 2016-02-14, 2016</unstructured_citation></citation><citation key="ref3"><doi>10.1021/j100540a008</doi></citation><citation key="ref4"><doi>10.18637/jss.v025.i12</doi></citation></citation_list>
       </journal_article>

--- a/joss.00043/10.21105.joss.00043.crossref.xml
+++ b/joss.00043/10.21105.joss.00043.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5957fb770231afccce6e3ddf78531d48</doi_batch_id>
-    <timestamp>20171023214708</timestamp>
+    <doi_batch_id>edc4c75bb43db835418de0598c3b4264</doi_batch_id>
+    <timestamp>20171024134936</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>43</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.60474</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/43</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00043</item_number>
+          <identifier id_type="doi">10.21105/joss.00043</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.60474</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/43</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00043</doi>
-          <timestamp>20171023214708</timestamp>
+          <timestamp>20171024134936</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00043</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00043/10.21105.joss.00043.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1002/jcc.540110911</doi></citation><citation key="ref2"><doi>10.1038/324446a0</doi></citation><citation key="ref3"><unstructured_citation>Baker, N. A. and Sept, D. and Holst, M. J. and McCammon, J. A., PNAS, 10037-10041, Electrostatics of Nanosystems: Application to microtubules and the ribosome, 98, 2001</unstructured_citation></citation><citation key="ref4"><unstructured_citation>DelPhi: a comprehensive suite for DelPhi software and associated resources, Li, Lin and Li, Chuan and Sarkar, Subhra and Zhang, Jie and Witham, Shawn and Zhang, Zhe and Wang, Lin and Smith, Nicholas and Petukh, Marharyta and Alexov, Emil, BMC biophysics, 5, 1, 9, 2012, BioMed Central Ltd</unstructured_citation></citation><citation key="ref5"><doi>DOI: 10.1016/j.cpc.2010.02.015</doi></citation><citation key="ref6"><unstructured_citation>Geng, W. H. and Krasny, R., J. Comput. Phys., 62–78, A treecode-accelerated boundary integral Poisson-Boltzmann solver for solvated biomolecules, 247, 2013</unstructured_citation></citation><citation key="ref7"><doi>10.1016/j.parco.2011.09.001</doi></citation><citation key="ref8"><unstructured_citation>Probing protein orientation near charged nanosurfaces for simulation-assisted biosensor design, Cooper, Christopher D and Clementi, Natalia C and Barba, Lorena A, J. Chem. Phys., 143, 12, 124709, 2015, Preprint on \hrefarxiv:1503.08150arxiv:1503.08150, AIP Publishing</unstructured_citation></citation><citation key="ref9"><doi>10.1016/j.cpc.2013.10.028</doi></citation><citation key="ref10"><unstructured_citation>Poisson–Boltzmann model for protein–surface electrostatic interactions and grid-convergence study using the PyGBe code, Cooper, Christopher D and Barba, Lorena A, Computer Physics Communications, 202, 23–32, 2016, Elsevier</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00044/10.21105.joss.00044.crossref.xml
+++ b/joss.00044/10.21105.joss.00044.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>1ecd4d54ac9845d387d056d9256ec12c</doi_batch_id>
-    <timestamp>20171023214717</timestamp>
+    <doi_batch_id>a5f455e8ead933dc7af4dc3e11258734</doi_batch_id>
+    <timestamp>20171024134937</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>44</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.200894</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/44</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00044</item_number>
+          <identifier id_type="doi">10.21105/joss.00044</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.200894</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/44</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00044</doi>
-          <timestamp>20171023214717</timestamp>
+          <timestamp>20171024134937</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00044</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00044/10.21105.joss.00044.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Raab, Markus, Elektra, 2016, http://www.libelektra.org, 2016-07-23</unstructured_citation></citation><citation key="ref2"><unstructured_citation>A modular approach to configuration storage, Raab, Markus, Master’s thesis, Vienna University of Technology, 2010</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Raab, Markus and Puntigam, Franz, Program Execution Environments As Contextual Values, Proceedings of 6th International Workshop on Context-Oriented Programming, 2014, 978-1-4503-2861-6, Uppsala, Sweden, 8:1–8:6, 8, 6, http://dx.doi.org/10.1145/2637066.2637074, 2637074, ACM, NY, USA</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Safe Management of Software Configuration, Raab, Markus, Proceedings of the CAiSE’2015 Doctoral Consortium, 2015, 74–82, http://ceur-ws.org/Vol-1415/, urn:nbn:de:0074-1415-4, http://ceur-ws.org/Vol-1415/CAISE2015DC09.pdf, context awareness, customization, persistency, key databases, information systems</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Sharing Software Configuration via Specified Links and Transformation Rules, Raab, Markus, Technical Report from KPS 2015, 18, 2015, Vienna University of Technology, Complang Group</unstructured_citation></citation><citation key="ref6"><doi>10.1145/2892664.2892691</doi></citation><citation key="ref7"><doi>10.1007/978-3-319-40171-3_4</doi></citation><citation key="ref8"><doi>10.1145/3001854.3001855</doi></citation></citation_list>
       </journal_article>

--- a/joss.00045/10.21105.joss.00045.crossref.xml
+++ b/joss.00045/10.21105.joss.00045.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>9c7e74bc7bb43d1373b1912ffad9101f</doi_batch_id>
-    <timestamp>20171023214726</timestamp>
+    <doi_batch_id>73cf70331581ca09c5f4e6d59ecbc8f1</doi_batch_id>
+    <timestamp>20171024134938</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>45</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.61064</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/45</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00045</item_number>
+          <identifier id_type="doi">10.21105/joss.00045</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.61064</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/45</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00045</doi>
-          <timestamp>20171023214726</timestamp>
+          <timestamp>20171024134938</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00045</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00045/10.21105.joss.00045.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref2"><unstructured_citation>Jones, Eric and Oliphant, Travis and Peterson, Pearu and others, SciPy: Open source scientific tools for Python, 2001, http://www.scipy.org/</unstructured_citation></citation><citation key="ref3"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref4"><unstructured_citation>Hinton, Samuel, ChainConsumer, 2016, https://github.com/samreay/ChainConsumer, 2016-07-24</unstructured_citation></citation><citation key="ref5"><doi>10.5281/zenodo.58511</doi></citation><citation key="ref6"><unstructured_citation>StatsModels Team, StatsModels: Statistics in Python, 2016, GitHub, GitHub repository, \urlhttps://github.com/statsmodels/statsmodels</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00046/10.21105.joss.00046.crossref.xml
+++ b/joss.00046/10.21105.joss.00046.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>84e8bc7ce157a2deb3bb289c4c8e892f</doi_batch_id>
-    <timestamp>20171023214737</timestamp>
+    <doi_batch_id>9df388283aa60dc1ef1e231b0d1a6d17</doi_batch_id>
+    <timestamp>20171024134940</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>46</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.159225</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/46</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00046</item_number>
+          <identifier id_type="doi">10.21105/joss.00046</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.159225</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/46</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00046</doi>
-          <timestamp>20171023214737</timestamp>
+          <timestamp>20171024134940</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00046</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00046/10.21105.joss.00046.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref2"><unstructured_citation>Foreman-Mackey, Daniel and Hogg, David W. and Lang, Dustin and Goodman, Jonathan, emcee: The MCMC Hammer, Publications of the Astronomical Society of the Pacific, 125, 925, 306, http://stacks.iop.org/1538-3873/125/i=925/a=306, 2013, We introduce a stable, well tested Python implementation of the affine-invariant ensemble sampler for Markov chain Monte Carlo (MCMC) proposed by Goodman & Weare (2010). The code is open source and has already been used in several published projects in the astrophysics literature. The algorithm behind emcee has several advantages over traditional MCMC sampling methods and it has excellent performance as measured by the autocorrelation time (or function calls per independent sample). One major advantage of the algorithm is that it requires hand-tuning of only 1 or 2 parameters compared to   N 2 for a traditional algorithm in an N -dimensional parameter space. In this document, we describe the algorithm and the details of our implementation. Exploiting the parallelism of the ensemble method, emcee permits any user to take advantage of multiple CPU cores without extra effort. The code is available online at http://dan.iel.fm/emcee under the GNU General Public License v2.</unstructured_citation></citation><citation key="ref3"><doi>10.21105/joss.00024</doi></citation><citation key="ref4"><unstructured_citation>Bocquet, Sebastian and Carter, Faustin W., pygtc GitHub repository, 2016, https://github.com/SebastianBocquet/pygtc</unstructured_citation></citation><citation key="ref5"><doi>10.5281/zenodo.159091</doi></citation><citation key="ref6"><unstructured_citation>Lewis, Antony, getdist GitHub repository, 2015, https://github.com/cmbant/getdist</unstructured_citation></citation><citation key="ref7"><doi>10.1051/0004-6361/201322971</doi></citation><citation key="ref8"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref9"><doi>http://dx.doi.org/10.1109/MCSE.2011.37</doi></citation></citation_list>
       </journal_article>

--- a/joss.00050/10.21105.joss.00050.crossref.xml
+++ b/joss.00050/10.21105.joss.00050.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>86aca61e1adfe14d11863a4a4f986c6d</doi_batch_id>
-    <timestamp>20171023214745</timestamp>
+    <doi_batch_id>66f54a2e6f8da947034068d71861b99a</doi_batch_id>
+    <timestamp>20171024134941</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>50</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.193078</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/50</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00050</item_number>
+          <identifier id_type="doi">10.21105/joss.00050</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.193078</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/50</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00050</doi>
-          <timestamp>20171023214745</timestamp>
+          <timestamp>20171024134941</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00050</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00050/10.21105.joss.00050.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>MassMine: Social Media and Online Web Content Mining Software, Van Horn, Nicholas M. and Beveridge, Aaron, https://github.com/n3mo/massmine, 2016-08-15, 2016</unstructured_citation></citation><citation key="ref2"><unstructured_citation>MassMine Official Website, Van Horn, Nicholas M. and Beveridge, Aaron, http://www.massmine.org, 2016-08-15, 2016</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00051/10.21105.joss.00051.crossref.xml
+++ b/joss.00051/10.21105.joss.00051.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5fa3b68b92891748c52251b20097ab1d</doi_batch_id>
-    <timestamp>20171023214756</timestamp>
+    <doi_batch_id>f7a8b1b35ba6ba3106cbc6fb0acdf2e1</doi_batch_id>
+    <timestamp>20171024134942</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>51</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.61033</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/51</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00051</item_number>
+          <identifier id_type="doi">10.21105/joss.00051</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.61033</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/51</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00051</doi>
-          <timestamp>20171023214756</timestamp>
+          <timestamp>20171024134942</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00051</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00051/10.21105.joss.00051.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.55270</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>waterData: An R Package for Retrieval, Analysis, and Anomaly Calculation of Daily Hydrologic Time Series Data, Ryberg, Karen R. and Vecchia, Aldo V., 2014, R package version 1.0.4, https://CRAN.R-project.org/package=waterData</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Vitolo, Claudia and Fry, Matthew and Buytaert, Wouter, rnrfa: UK National River Flow Archive Data from R, 2015, R package version 0.5.3, https://CRAN.R-project.org/package=rnrfa</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00052/10.21105.joss.00052.crossref.xml
+++ b/joss.00052/10.21105.joss.00052.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5fd7c43eac4571ff95c2aafd2baaac1e</doi_batch_id>
-    <timestamp>20171023214804</timestamp>
+    <doi_batch_id>dc7df05780a850847baae40c061498b0</doi_batch_id>
+    <timestamp>20171024134943</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>52</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.212822</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/52</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00052</item_number>
+          <identifier id_type="doi">10.21105/joss.00052</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.212822</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/52</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00052</doi>
-          <timestamp>20171023214804</timestamp>
+          <timestamp>20171024134943</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00052</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00052/10.21105.joss.00052.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.61639</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><doi>10.1029/2007WR006735</doi></citation><citation key="ref4"><doi>http://dx.doi.org/10.1016/j.envsoft.2014.10.007</doi></citation><citation key="ref5"><doi>10.1016/j.jenvman.2015.06.009</doi></citation><citation key="ref6"><unstructured_citation>topmodel: Implementation of the hydrological model TOPMODEL in R, Buytaert, Wouter, 2011, R package version 0.7.2-2, https://CRAN.R-project.org/package=topmodel</unstructured_citation></citation><citation key="ref7"><unstructured_citation>dynatopmodel: Implementation of the Dynamic TOPMODEL Hydrological Model, Metcalfe, Peter and Beven, Keith and Freer, Jim, 2016, R package version 1.1, https://CRAN.R-project.org/package=dynatopmodel</unstructured_citation></citation><citation key="ref8"><unstructured_citation>wasim: Visualisation and analysis of output files of the hydrological model WASIM, Reusser, Dominik and Francke, Till, 2011, R package version 1.1.2, https://CRAN.R-project.org/package=wasim</unstructured_citation></citation><citation key="ref9"><doi>10.1016/j.envsoft.2011.04.006</doi></citation></citation_list>
       </journal_article>

--- a/joss.00053/10.21105.joss.00053.crossref.xml
+++ b/joss.00053/10.21105.joss.00053.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>cbf778a20c012d6fb8788d3eeed9c18b</doi_batch_id>
-    <timestamp>20171023214813</timestamp>
+    <doi_batch_id>58cc3ad2ac2093ee0158aff9e043dcd7</doi_batch_id>
+    <timestamp>20171024134945</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>53</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.200893</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/53</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00053</item_number>
+          <identifier id_type="doi">10.21105/joss.00053</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.200893</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/53</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00053</doi>
-          <timestamp>20171023214813</timestamp>
+          <timestamp>20171024134945</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00053</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00053/10.21105.joss.00053.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1093/nar/gkt1178</doi></citation></citation_list>
       </journal_article>

--- a/joss.00054/10.21105.joss.00054.crossref.xml
+++ b/joss.00054/10.21105.joss.00054.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>2eb353634073b299afa23c80767840da</doi_batch_id>
-    <timestamp>20171023214821</timestamp>
+    <doi_batch_id>36727259078a8c81ef5256ecbd2f717d</doi_batch_id>
+    <timestamp>20171024134946</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>54</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.60878</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/54</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00054</item_number>
+          <identifier id_type="doi">10.21105/joss.00054</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.60878</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/54</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00054</doi>
-          <timestamp>20171023214821</timestamp>
+          <timestamp>20171024134946</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00054</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00054/10.21105.joss.00054.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Pebesma, Edzer J. and Bivand, Roger S., Classes and methods for spatial data in R, R News, 2005, 5, 2, 9–13, http://CRAN.R-project.org/doc/Rnews/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Bivand, Roger S. and Pebesma, Edzer and Gomez-Rubio, Virgilio, Applied spatial data analysis with R, Second edition, 2013, Springer, NY, http://www.asdar-book.org/</unstructured_citation></citation><citation key="ref4"><unstructured_citation>rgeos: Interface to Geometry Engine - Open Source (GEOS), Bivand, Roger and Rundel, Colin, 2016, R package version 0.3-19, https://CRAN.R-project.org/package=rgeos</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00055/10.21105.joss.00055.crossref.xml
+++ b/joss.00055/10.21105.joss.00055.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>0fa6eb23555f14a306f6cf8ec8d5d945</doi_batch_id>
-    <timestamp>20171023214830</timestamp>
+    <doi_batch_id>fb1c5cc77ab2280844c0de37f8ddea8f</doi_batch_id>
+    <timestamp>20171024134947</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>55</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.155066</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/55</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00055</item_number>
+          <identifier id_type="doi">10.21105/joss.00055</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.155066</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/55</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00055</doi>
-          <timestamp>20171023214830</timestamp>
+          <timestamp>20171024134947</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00055</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00055/10.21105.joss.00055.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1007/978-1-4614-6868-4</doi></citation><citation key="ref2"><unstructured_citation>Rcpp: Seamless R and C++ Integration, Eddelbuettel, Dirk and François, Romain and Allaire, JJ and Ushey, Kevin and Kou, Qiang and Chambers, John and Bates, Douglas, 2016, R package version 0.12.7, https://CRAN.R-Project.org/package=Rcpp</unstructured_citation></citation><citation key="ref3"><unstructured_citation>RcppCNPy: Read-Write Support for ’NumPy’ Files via ’Rcpp’, Eddelbuettel, Dirk and Wu, Wush, 2016, R package version 0.2.5, https://CRAN.R-Project.org/package=RcppCNPy</unstructured_citation></citation><citation key="ref4"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref5"><unstructured_citation>Rogers, Carl, cnpy, 2015, GitHub, GitHub repository, \urlhttps://github.com/rogersce/cnpy, 4f57d6a0e4c030202a07a60bc1bb1ed1544bf679</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00056/10.21105.joss.00056.crossref.xml
+++ b/joss.00056/10.21105.joss.00056.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c1a60c81ab5ea62844ec2dbff14a4d06</doi_batch_id>
-    <timestamp>20171023214838</timestamp>
+    <doi_batch_id>3334b61bf96c7fb133dbd6abdd5e96c4</doi_batch_id>
+    <timestamp>20171024134948</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>56</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.247842</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/56</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00056</item_number>
+          <identifier id_type="doi">10.21105/joss.00056</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.247842</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/56</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00056</doi>
-          <timestamp>20171023214838</timestamp>
+          <timestamp>20171024134948</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00056</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00056/10.21105.joss.00056.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.61570</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><doi>10.21105/joss.00051</doi></citation><citation key="ref4"><unstructured_citation>Vitolo, Claudia and Fry, Matthew and Buytaert, Wouter, rnrfa: UK National River Flow Archive Data from R, 2015, R package version 0.5.3, https://CRAN.R-project.org/package=rnrfa</unstructured_citation></citation><citation key="ref5"><doi>http://dx.doi.org/10.5281/zenodo.14005</doi></citation><citation key="ref6"><doi>10.21105/joss.00052</doi></citation><citation key="ref7"><unstructured_citation>topmodel: Implementation of the hydrological model TOPMODEL in R, Buytaert, Wouter, 2011, R package version 0.7.2-2, https://CRAN.R-project.org/package=topmodel</unstructured_citation></citation><citation key="ref8"><unstructured_citation>hydromad: Hydrological Model Assessment and Development, Andrews, Felix and Guillaume, Joseph, 2016, R package version 0.9-25, http://hydromad.catchment.org/</unstructured_citation></citation><citation key="ref9"><doi>http://dx.doi.org/10.1016/j.envsoft.2011.04.006</doi></citation></citation_list>
       </journal_article>

--- a/joss.00058/10.21105.joss.00058.crossref.xml
+++ b/joss.00058/10.21105.joss.00058.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a8abb2fa7bf604d33b954a0eed05a0f8</doi_batch_id>
-    <timestamp>20171023214846</timestamp>
+    <doi_batch_id>92cc08db2fa864bed9a02a9cd61069d9</doi_batch_id>
+    <timestamp>20171024134949</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>58</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.159035</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/58</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00058</item_number>
+          <identifier id_type="doi">10.21105/joss.00058</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.159035</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/58</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00058</doi>
-          <timestamp>20171023214846</timestamp>
+          <timestamp>20171024134949</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00058</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00058/10.21105.joss.00058.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1051/aas:1996164</doi></citation><citation key="ref2"><unstructured_citation>Bertin, Emanuel, SExtractor, 2016, http://www.astromatic.net/software/sextractor, 2016-08-25</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00060/10.21105.joss.00060.crossref.xml
+++ b/joss.00060/10.21105.joss.00060.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f0ef76011002221f3fe94f8809206ade</doi_batch_id>
-    <timestamp>20171023214854</timestamp>
+    <doi_batch_id>b5d2c7e52dde50b10589f09d00003ef5</doi_batch_id>
+    <timestamp>20171024134950</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>60</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.154745</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/60</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00060</item_number>
+          <identifier id_type="doi">10.21105/joss.00060</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.154745</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/60</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00060</doi>
-          <timestamp>20171023214854</timestamp>
+          <timestamp>20171024134950</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00060</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00060/10.21105.joss.00060.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/j.neuron.2015.04.014</doi></citation><citation key="ref2"><doi>10.1016/j.neuron.2014.04.045</doi></citation><citation key="ref3"><doi>10.1038/nn.3405</doi></citation><citation key="ref4"><unstructured_citation>Martens, J and Sutskever, I, Learning recurrent neural networks with hessian-free optimization, Proceedings of the 28th International Conference on Machine Learning, 2011</unstructured_citation></citation><citation key="ref5"><doi>10.1101/057729</doi></citation><citation key="ref6"><doi>10.1016/j.neuron.2016.02.009</doi></citation><citation key="ref7"><doi>10.1371/journal.pcbi.1004792</doi></citation><citation key="ref8"><doi>10.1038/nn.4042</doi></citation><citation key="ref9"><doi>10.1016/j.neuron.2009.07.018</doi></citation></citation_list>
       </journal_article>

--- a/joss.00061/10.21105.joss.00061.crossref.xml
+++ b/joss.00061/10.21105.joss.00061.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>65f3243efa1d94d45c7687f5e8a8b4e7</doi_batch_id>
-    <timestamp>20171023214902</timestamp>
+    <doi_batch_id>2fbaca532fb51a63db70ca4e4406cd29</doi_batch_id>
+    <timestamp>20171024134951</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>61</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.400944</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/61</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00061</item_number>
+          <identifier id_type="doi">10.21105/joss.00061</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.400944</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/61</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00061</doi>
-          <timestamp>20171023214902</timestamp>
+          <timestamp>20171024134951</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00061</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00061/10.21105.joss.00061.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1287/moor.1110.0519</doi></citation><citation key="ref2"><doi>10.1214/ss/1177011136</doi></citation><citation key="ref3"><doi>10.1.1.170.9791</doi></citation><citation key="ref4"><unstructured_citation>Gabry, Jonah, Interactive Visual and Numerical Diagnostics and Posterior Analysis for for Bayesian Models, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00062/10.21105.joss.00062.crossref.xml
+++ b/joss.00062/10.21105.joss.00062.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>19f128a5c484e5f35e4d6425b56e5588</doi_batch_id>
-    <timestamp>20171023214910</timestamp>
+    <doi_batch_id>79a44ce3ab0a1ed43996bef44aa9df5e</doi_batch_id>
+    <timestamp>20171024134953</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>62</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.165764</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/62</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00062</item_number>
+          <identifier id_type="doi">10.21105/joss.00062</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.165764</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/62</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00062</doi>
-          <timestamp>20171023214910</timestamp>
+          <timestamp>20171024134953</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00062</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00062/10.21105.joss.00062.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>A model of tungsten anode x-ray spectra, Hernández, G and Fernández, F, Medical Physics, 43, 8, 4655–4664, 2016, American Association of Physicists in Medicine</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00063/10.21105.joss.00063.crossref.xml
+++ b/joss.00063/10.21105.joss.00063.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e570bcf729884352f9a90605743534ff</doi_batch_id>
-    <timestamp>20171023214918</timestamp>
+    <doi_batch_id>230556c600fc801e77d4aa4dcd44ece5</doi_batch_id>
+    <timestamp>20171024134954</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>63</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.160211</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/63</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00063</item_number>
+          <identifier id_type="doi">10.21105/joss.00063</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.160211</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/63</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00063</doi>
-          <timestamp>20171023214918</timestamp>
+          <timestamp>20171024134954</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00063</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00063/10.21105.joss.00063.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>shiny: Web Application Framework for R, Chang, Winston and Cheng, Joe and Allaire, JJ and Xie, Yihui and McPherson, Jonathan, 2016, R package version 0.14, http://CRAN.R-project.org/package=shiny</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Intro.js: Better introductions for websites and features with a step-by-step guide for your projects, Mehrabani, Afshin, 2016, JS library version 2.3.0, http://introjs.com</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00064/10.21105.joss.00064.crossref.xml
+++ b/joss.00064/10.21105.joss.00064.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>400f8ae890aa67b36fe9c14500410c74</doi_batch_id>
-    <timestamp>20171023214927</timestamp>
+    <doi_batch_id>388e184dd72d3b0e1322b7bf7ef766fd</doi_batch_id>
+    <timestamp>20171024134955</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>64</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.240977</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/64</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00064</item_number>
+          <identifier id_type="doi">10.21105/joss.00064</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.240977</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/64</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00064</doi>
-          <timestamp>20171023214927</timestamp>
+          <timestamp>20171024134955</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00064</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00064/10.21105.joss.00064.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5194/gmd-8-2687-2015</doi></citation><citation key="ref2"><doi>10.1016/j.ecolmodel.2003.09.003</doi></citation><citation key="ref3"><doi>10.1016/j.ecolmodel.2015.06.031</doi></citation><citation key="ref4"><unstructured_citation>Lucey, Sean M and Gaichas, Sarah K. and Aydin, Kerim Y., Improving the EBFM toolbox with an alternative open source version of Ecopath with Ecosim, in prep.</unstructured_citation></citation><citation key="ref5"><doi>10.1111/fog.12118</doi></citation><citation key="ref6"><doi>10.3354/meps10484</doi></citation><citation key="ref7"><doi>10.1016/j.ecolmodel.2012.04.006</doi></citation><citation key="ref8"><doi>10.1016/j.ecolmodel.2015.05.036</doi></citation><citation key="ref9"><unstructured_citation>Over the past decade, fisheries management efforts have placed increased emphasis on ecosystem-based management, where the interactions between a target stock species and its physical and biological environment are considered in addition to sustainability of the stock itself. At the same time, global-scale climate models that historically focused only on physical and biogeochemical variables are increasingly incorporating biological variables. With these shifts, the historical separation between climate modeling and fisheries modeling is closing, with increased interest in the concept of end-to-end models, i.e. models that incorporate dynamics from physics to top predators. In this dissertation, I develop a modeling framework that fully couples a one-dimensional physical mixed layer model, a biogeochemical model, and an upper trophic level fisheries food web model. I present a thorough description of the model itself, as well as an ensemble-based parameterization process that allows the model to incorporate the high level of uncertainty associated with many upper trophic level predator-prey processes. Through a series of model architecture experiments, I demonstrate that the use of a consistent functional response for all predator-prey interactions, as well as the use of density-dependent mortality rates for planktonic functional groups, are important factors in reproducing annual and seasonal observations. Following the development and validation of the end-to-end ecosystem model, I use the model to simulate the response of an ecosystem to a bottom-up perturbation, namely an increase in net primary production due to alleviation of micronutrient limitation. I also look at the impact of non-predatory mortality, one of the least-constrained model processes, on the energy flow through the system. We find that the relative changes in production at higher trophic levels are amplified under density-independent non-predatory mortality assumptions but damped under density-dependent assumptions. However, the high parameter uncertainty masks this effect in predicted values for most functional groups. Overall, the model developed in this dissertation addresses a growing need to thoroughly diagnose the behavior of, and quantify the uncertainty associated with, complex ecosystem models that bridge physical, biological, and socio-economic boundaries. Such detailed dynamical characterization of model behavior is essential before ecosystem models can be applied to management applications., Kearney, Kelly Anne, :Users/kakearney/Documents/Mendeley Desktop/Kearney - 2012 - An analysis of marine ecosystem dynamics through development of a coupled physical-biogeochemical-fisheries food web mo.pdf:pdf, November, 179, Princeton University, An analysis of marine ecosystem dynamics through development of a coupled physical-biogeochemical-fisheries food web model, 2012</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00075/10.21105.joss.00075.crossref.xml
+++ b/joss.00075/10.21105.joss.00075.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>651058e76d2854d7fd0e1cdd085fd7b4</doi_batch_id>
-    <timestamp>20171023214936</timestamp>
+    <doi_batch_id>29dae98bec70739b2b9cdb76008d95b2</doi_batch_id>
+    <timestamp>20171024134956</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>75</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.3545363</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/75</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00075</item_number>
+          <identifier id_type="doi">10.21105/joss.00075</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.3545363</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/75</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00075</doi>
-          <timestamp>20171023214936</timestamp>
+          <timestamp>20171024134956</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00075</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00075/10.21105.joss.00075.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.6084/m9.figshare.3545363</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>knitr: A General-Purpose Package for Dynamic Report Generation in R, Xie, Yihui, 2014, R package version 1.13.7, https://CRAN.R-project.org/package=knitr</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Literate programming, Knuth, Donald Ervin, The Computer Journal, 27, 2, 97–111, 1984, Br Computer Soc</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00079/10.21105.joss.00079.crossref.xml
+++ b/joss.00079/10.21105.joss.00079.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5ea79cd96353721e6bb214e87d8f3506</doi_batch_id>
-    <timestamp>20171023214944</timestamp>
+    <doi_batch_id>ba21b166106b62955eb71d7b0b8a2c86</doi_batch_id>
+    <timestamp>20171024134957</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>79</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">http://doi.org/10.5281/zenodo.158941</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/79</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00079</item_number>
+          <identifier id_type="doi">10.21105/joss.00079</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://doi.org/10.5281/zenodo.158941</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/79</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00079</doi>
-          <timestamp>20171023214944</timestamp>
+          <timestamp>20171024134957</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00079</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00079/10.21105.joss.00079.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Active subspace methods in theory and practice: Applications to kriging surfaces, Constantine, Paul G. and Dow, Eric and Wang, Qiqi, SIAM Journal on Scientific Computing, 2014, 4, A1500–A1524, 36, http://dx.doi.org/10.1137/130916138</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Active Subspaces: Emerging Ideas for Dimension Reduction in Parameter Studies, Constantine, Paul G., SIAM, Philadelphia, 2015, http://dx.doi.org/10.1137/1.9781611973860</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Python Active-subspaces Utility Library, 2016, https://github.com/paulcon/active_subspaces</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00080/10.21105.joss.00080.crossref.xml
+++ b/joss.00080/10.21105.joss.00080.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>67dbd9798c6a06d3ef7c1a27a4a7c6a3</doi_batch_id>
-    <timestamp>20171023214952</timestamp>
+    <doi_batch_id>9700042ede7b93f3801d0178a1f821ce</doi_batch_id>
+    <timestamp>20171024134958</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>80</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3988815.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/80</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00080</item_number>
+          <identifier id_type="doi">10.21105/joss.00080</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3988815.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/80</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00080</doi>
-          <timestamp>20171023214952</timestamp>
+          <timestamp>20171024134958</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00080</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00080/10.21105.joss.00080.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Page, Andrew J. and De Silva, Nishadi and Hunt, Martin and Quail, Michael A. and Parkhill, Julian and Harris, Simon R. and Otto, Thomas D. and Keane, Jacqueline A., Robust high-throughput prokaryote de novo assembly and improvement pipeline for Illumina data, Microbial Genomics, 2016, 2, 8, http://mgen.microbiologyresearch.org/content/journal/mgen/10.1099/mgen.0.000083</unstructured_citation></citation><citation key="ref2"><doi>10.1093/bioinformatics/btu153</doi></citation><citation key="ref3"><doi>10.1126/science.aaf7672</doi></citation><citation key="ref4"><doi>10.1109/TCBB.2013.68</doi></citation></citation_list>
       </journal_article>

--- a/joss.00082/10.21105.joss.00082.crossref.xml
+++ b/joss.00082/10.21105.joss.00082.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ac7b4f891dba12c5b04d074d54035365</doi_batch_id>
-    <timestamp>20171023215005</timestamp>
+    <doi_batch_id>60249869611b96c769a99ac3956c231a</doi_batch_id>
+    <timestamp>20171024134959</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>82</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163291</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/82</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00082</item_number>
+          <identifier id_type="doi">10.21105/joss.00082</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163291</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/82</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00082</doi>
-          <timestamp>20171023215005</timestamp>
+          <timestamp>20171024134959</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00082</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00082/10.21105.joss.00082.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>J.C., Adams and W.S., Brainerd and J.T., Martin and B.T., Smith and J.L., Wagener, Fortran 95 Handbook - Complete ISO/ANSI Reference, 1997, The MIT Press, Cambridge, Massachusetts, London, England, https://mitpress.mit.edu/books/fortran-95-handbook</unstructured_citation></citation><citation key="ref2"><unstructured_citation>C.J., Brookes and V., Kumar and S.N., Lane, A comparison of Fuzzy, Bayesian and Weighted Average formulations of an in-stream habitat suitability model, International Congress on Environmental Modelling and Software, 2010, http://www.iemss.org/iemss2010/papers/S20/S.20.07.Model%20selection%20and%20uncertainty%20A%20comparison%20of%20Fuzzy,%20Bayesian%20and%20Weighted%20Average%20formulations%20of%20an%20instream%20habitat%20suitability%20model%20-%20CHRISTOPHER%20BROOKES.pdf, 2016-09-21</unstructured_citation></citation><citation key="ref3"><doi>10.1016/S0020-7373(75)80002-2</doi></citation><citation key="ref4"><unstructured_citation>T.J., Ross, Fuzzy logic with engineering applications, 2010, John Wiley and Sons, UK, https://mitpress.mit.edu/books/fortran-95-handbook</unstructured_citation></citation><citation key="ref5"><unstructured_citation>C., Theodoropoulos and N., Skoulikidis and A., Stamou, Habfuzz: A tool to calculate the instream hydraulic habitat suitability based on fuzzy logic and fuzzy Bayesian inference, 2016, https://github.com/chtheodoro/habfuzz, 2016-09-21</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00085/10.21105.joss.00085.crossref.xml
+++ b/joss.00085/10.21105.joss.00085.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d71aa2ae8eeb7001a2e7c9e52dca02d0</doi_batch_id>
-    <timestamp>20171023215014</timestamp>
+    <doi_batch_id>6311a426ecec9333673adcf7cafa3bde</doi_batch_id>
+    <timestamp>20171024135000</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>85</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3863583.v2</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/85</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00085</item_number>
+          <identifier id_type="doi">10.21105/joss.00085</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.6084/m9.figshare.3863583.v2</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/85</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00085</doi>
-          <timestamp>20171023215014</timestamp>
+          <timestamp>20171024135000</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00085</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00085/10.21105.joss.00085.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The variant call format and VCFtools, Danecek, Petr and Auton, Adam and Abecasis, Goncalo and Albers, Cornelis A and Banks, Eric and DePristo, Mark A and Handsaker, Robert E and Lunter, Gerton and Marth, Gabor T and Sherry, Stephen T and others, Bioinformatics, 27, 15, 2156–2158, 2011, Oxford Univ Press</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00087/10.21105.joss.00087.crossref.xml
+++ b/joss.00087/10.21105.joss.00087.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e56e1e23ed71e83b35477f89bdff54d4</doi_batch_id>
-    <timestamp>20171023215022</timestamp>
+    <doi_batch_id>370c478ae90ebe17e993b60175e657e4</doi_batch_id>
+    <timestamp>20171024135001</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>87</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163510</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/87</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00087</item_number>
+          <identifier id_type="doi">10.21105/joss.00087</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163510</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/87</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00087</doi>
-          <timestamp>20171023215022</timestamp>
+          <timestamp>20171024135001</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00087</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00087/10.21105.joss.00087.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1093/bioinformatics/btq565</doi></citation><citation key="ref2"><doi>10.1101/gr.1239303</doi></citation><citation key="ref3"><doi>10.21105/joss.00025</doi></citation><citation key="ref4"><doi>10.1126/science.1069516</doi></citation><citation key="ref5"><doi>10.1038/ng1815</doi></citation><citation key="ref6"><doi>10.1371/journal.pcbi.1002458</doi></citation><citation key="ref7"><unstructured_citation>Team, RDC, 3900051070, R foundation for Statistical Computing, R: A language and environment for statistical computing, http://r-project.kr/sites/default/files/2%EA%B0%95%EA%B0%95%EC%A2%8C%EC%86%8C%EA%B0%9C_%EC%8B%A0%EC%A2%85%ED%99%94.pdf, 1, 2005</unstructured_citation></citation><citation key="ref8"><unstructured_citation>High-throughput computational methods and software for quantitative trait locus (QTL) mapping, Arends, Danny, 2014, 978-90-367-7210-5, http://hdl.handle.net/11370/29cf3cc5-6596-4d5a-a87c-490b31676a96</unstructured_citation></citation><citation key="ref9"><doi>10.1038/nrg2884</doi></citation></citation_list>
       </journal_article>

--- a/joss.00091/10.21105.joss.00091.crossref.xml
+++ b/joss.00091/10.21105.joss.00091.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7e07a5a37becc651b4a5faad9f353e46</doi_batch_id>
-    <timestamp>20171023215034</timestamp>
+    <doi_batch_id>0830f2183814c6ac0aef7e0ac1842248</doi_batch_id>
+    <timestamp>20171024135002</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>91</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.250879</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/91</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00091</item_number>
+          <identifier id_type="doi">10.21105/joss.00091</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.250879</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/91</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00091</doi>
-          <timestamp>20171023215034</timestamp>
+          <timestamp>20171024135002</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00091</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00091/10.21105.joss.00091.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Efficient estimation of word representations in vector space, Mikolov, Tomas and Chen, Kai and Corrado, Greg and Dean, Jeffrey, arXiv preprint arXiv:1301.3781, 2013</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Geonames, Geonames, 2016, http://geonames.org, 2016-09-08</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00092/10.21105.joss.00092.crossref.xml
+++ b/joss.00092/10.21105.joss.00092.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>2ad6fd996d2efbaa3f9877b94b488f02</doi_batch_id>
-    <timestamp>20171023215047</timestamp>
+    <doi_batch_id>6af155cacd3d54990cf757421c478aea</doi_batch_id>
+    <timestamp>20171024135003</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>92</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.162238</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/92</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00092</item_number>
+          <identifier id_type="doi">10.21105/joss.00092</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.162238</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/92</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00092</doi>
-          <timestamp>20171023215047</timestamp>
+          <timestamp>20171024135003</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00092</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00092/10.21105.joss.00092.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1214/aos/1013203451</doi></citation><citation key="ref2"><doi>10.1111/ajps.12166</doi></citation><citation key="ref3"><unstructured_citation>Exploratory data analysis using random forests, Jones, Zachary M. and Linder, Fridolin, Proceedings of the 73rd annual MPSA conference, 2015, http://zmjones.com/static/papers/rfss_manuscript.pdf</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Is There More Violence in the Middle?, Jones, Zachary M. and Lupu, Yonatan, 2016</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Classification and Regression by randomForest, Liaw, Andy and Wiener, Matthew, R News, 2002, 2, 3, 18-22, http://CRAN.R-project.org/doc/Rnews/</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Random forests for survival, regression and classification (RF-SRC), Ishwaran, H and Kogalur, U, URL http://cran.r-project.org/web/packages/randomForestSRC/. R package version, 1, 2013</unstructured_citation></citation><citation key="ref7"><doi>10.1198/106186006X133933</doi></citation></citation_list>
       </journal_article>

--- a/joss.00093/10.21105.joss.00093.crossref.xml
+++ b/joss.00093/10.21105.joss.00093.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>0a387ebced5d82c49793dc5aa3464e2e</doi_batch_id>
-    <timestamp>20171023215056</timestamp>
+    <doi_batch_id>1f2c107fb1123d9868a3cc79547cbd69</doi_batch_id>
+    <timestamp>20171024135005</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>93</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.192097</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/93</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00093</item_number>
+          <identifier id_type="doi">10.21105/joss.00093</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.192097</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/93</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00093</doi>
-          <timestamp>20171023215056</timestamp>
+          <timestamp>20171024135005</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00093</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00093/10.21105.joss.00093.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1145/2500828.2500844</doi></citation><citation key="ref2"><doi>10.1145/2786545.2786552</doi></citation><citation key="ref3"><unstructured_citation>Ponge, Julien and Mouël, Frédéric Le and Stouls, Nicolas and Loiseau, Yannick, Opportunities for a Truffle-based Golo Interpreter, CoRR, abs/1505.06003, 2015, http://arxiv.org/abs/1505.06003, Mon, 01 Jun 2015 14:13:54 +0200, http://dblp.uni-trier.de/rec/bib/journals/corr/PongeMSL15, dblp computer science bibliography, http://dblp.org</unstructured_citation></citation><citation key="ref4"><doi>10.1145/178243.178478</doi></citation><citation key="ref5"><doi>10.1145/1852761.1852763</doi></citation></citation_list>
       </journal_article>

--- a/joss.00097/10.21105.joss.00097.crossref.xml
+++ b/joss.00097/10.21105.joss.00097.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>17971dc59f25a8b5b85c7e0d7fc6de1e</doi_batch_id>
-    <timestamp>20171023215104</timestamp>
+    <doi_batch_id>d26eb4b277995dc2a4106719f7dd5980</doi_batch_id>
+    <timestamp>20171024135008</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>97</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.233103</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/97</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00097</item_number>
+          <identifier id_type="doi">10.21105/joss.00097</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.233103</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/97</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00097</doi>
-          <timestamp>20171023215104</timestamp>
+          <timestamp>20171024135008</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00097</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00097/10.21105.joss.00097.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/S0378-4754(00)00270-6</doi></citation><citation key="ref2"><doi>10.1016/S0010-4655(02)00280-1</doi></citation><citation key="ref3"><doi>10.1016/j.cpc.2009.09.018</doi></citation><citation key="ref4"><doi>10.2307/1269043</doi></citation><citation key="ref5"><doi>10.1016/j.envsoft.2006.10.004</doi></citation><citation key="ref6"><doi>10.1063/1.1680571</doi></citation><citation key="ref7"><doi>10.1080/00401706.1999.10485594</doi></citation><citation key="ref8"><doi>10.1016/j.ress.2006.04.015</doi></citation><citation key="ref9"><doi>10.1016/j.ejor.2012.11.047</doi></citation><citation key="ref10"><doi>10.1016/j.matcom.2009.01.023</doi></citation><citation key="ref11"><unstructured_citation>Saltelli, Andrea and Ratto, M and Andres, T and Campolongo, F and Cariboni, J and Gatelli, D and Saisana, M and Tarantola, S., 9780470725177, Wiley, Global Sensitivity Analysis: The Primer, http://books.google.co.uk/books?id=wAssmt2vumgC, 2008</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00100/10.21105.joss.00100.crossref.xml
+++ b/joss.00100/10.21105.joss.00100.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7d0e1fb2deb5accf770d7820ab956d66</doi_batch_id>
-    <timestamp>20171023215112</timestamp>
+    <doi_batch_id>a57e320b6adfb87116d8539e0c490544</doi_batch_id>
+    <timestamp>20171024135009</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>100</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.164995</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/100</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00100</item_number>
+          <identifier id_type="doi">10.21105/joss.00100</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.164995</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/100</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00100</doi>
-          <timestamp>20171023215112</timestamp>
+          <timestamp>20171024135009</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00100</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00100/10.21105.joss.00100.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1145/2339530.2339576</doi></citation><citation key="ref2"><unstructured_citation>Using Dynamic Time Warping to Find Patterns in Time Series., Berndt, Donald J and Clifford, James, KDD workshop, 10, 16, 359–370, 1994, AAAI, http://www.aaai.org/Library/Workshops/1994/ws94-03-031.php</unstructured_citation></citation><citation key="ref3"><doi>10.18637/jss.v040.i08</doi></citation><citation key="ref4"><unstructured_citation>Alcock, R. J. and Manolopoulos, Y. and Laboratory, Data Engineering and Informatics, Department Of, Time-series similarity queries employing a feature-based approach, In 7 th Hellenic Conference on Informatics, Ioannina, 1999, 27–29</unstructured_citation></citation><citation key="ref5"><doi>10.18637/jss.v031.i07</doi></citation></citation_list>
       </journal_article>

--- a/joss.00102/10.21105.joss.00102.crossref.xml
+++ b/joss.00102/10.21105.joss.00102.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>9bc72ca1302b43c0affb0e394b0ebced</doi_batch_id>
-    <timestamp>20171023215125</timestamp>
+    <doi_batch_id>a34fb6a60819f028275a1ac3d55b5198</doi_batch_id>
+    <timestamp>20171024135010</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>102</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.570881</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/102</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00102</item_number>
+          <identifier id_type="doi">10.21105/joss.00102</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.570881</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/102</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00102</doi>
-          <timestamp>20171023215125</timestamp>
+          <timestamp>20171024135010</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00102</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00102/10.21105.joss.00102.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.47652</doi></citation></citation_list>
       </journal_article>

--- a/joss.00103/10.21105.joss.00103.crossref.xml
+++ b/joss.00103/10.21105.joss.00103.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>995c0c7ea2ae2c0ffa8bafe31958eeae</doi_batch_id>
-    <timestamp>20171023215133</timestamp>
+    <doi_batch_id>f7c8a83e1c2b517f78fd1ca2ad2c69d6</doi_batch_id>
+    <timestamp>20171024135011</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>103</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.176596</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/103</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00103</item_number>
+          <identifier id_type="doi">10.21105/joss.00103</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.176596</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/103</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00103</doi>
-          <timestamp>20171023215133</timestamp>
+          <timestamp>20171024135011</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00103</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00103/10.21105.joss.00103.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>DeSimone, Kevin, popeye: a population receptive field estimation tool, 2016, https://github.com/kdesimone/popeye, 2016-11-10</unstructured_citation></citation><citation key="ref2"><doi>10.1016/j.neuroimage.2007.09.034</doi></citation><citation key="ref3"><doi>10.1016/j.neuroimage.2014.10.060</doi></citation><citation key="ref4"><doi>10.1126/science.1239052</doi></citation><citation key="ref5"><doi>10.1523/jneurosci.3840-14.2015</doi></citation></citation_list>
       </journal_article>

--- a/joss.00106/10.21105.joss.00106.crossref.xml
+++ b/joss.00106/10.21105.joss.00106.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>78011190a9ee474ba75f4e0ec788946a</doi_batch_id>
-    <timestamp>20171023215141</timestamp>
+    <doi_batch_id>b60358608e2be91aa738e9901eaa2f46</doi_batch_id>
+    <timestamp>20171024135012</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>106</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163543</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/106</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00106</item_number>
+          <identifier id_type="doi">10.21105/joss.00106</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.163543</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/106</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00106</doi>
-          <timestamp>20171023215141</timestamp>
+          <timestamp>20171024135012</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00106</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00106/10.21105.joss.00106.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><doi>10.18637/jss.v059.i10</doi></citation></citation_list>
       </journal_article>

--- a/joss.00107/10.21105.joss.00107.crossref.xml
+++ b/joss.00107/10.21105.joss.00107.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f897d0e672df606b90fff5d4aeb8442f</doi_batch_id>
-    <timestamp>20171023215150</timestamp>
+    <doi_batch_id>4907038e983f3ac69a2c0bbbde22f72b</doi_batch_id>
+    <timestamp>20171024135014</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>107</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.159604</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/107</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00107</item_number>
+          <identifier id_type="doi">10.21105/joss.00107</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.159604</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/107</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00107</doi>
-          <timestamp>20171023215150</timestamp>
+          <timestamp>20171024135014</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00107</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00107/10.21105.joss.00107.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>https://doi.org/10.5281/zenodo.159604</doi></citation><citation key="ref2"><unstructured_citation>Fernando Chirigati, Rémi Rampin, Vicky Steeves, ReproZip Website, 2016, https://vida-nyu.github.io/reprozip/, 2016-12-01</unstructured_citation></citation><citation key="ref3"><doi>http://doi.org/10.17605/OSF.IO/JB2UV</doi></citation><citation key="ref4"><unstructured_citation>Rémi Rampin, Fernando Chrigiati, Vicky Steeves, ReproZip Documentation, \urlhttps://reprozip.readthedocs.io/en/1.0.x/</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Packing and Unpacking Experiments with ReproZip, 2015, Youtube, Fernando Chirigati, Vicky Steeves, https://www.youtube.com/watch?v=-zLPuwCHXo0</unstructured_citation></citation><citation key="ref6"><doi>10.1145/2882903.2899401</doi></citation></citation_list>
       </journal_article>

--- a/joss.00111/10.21105.joss.00111.crossref.xml
+++ b/joss.00111/10.21105.joss.00111.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>cb9506e6adad6bbae4af9a90d4c45875</doi_batch_id>
-    <timestamp>20171023215159</timestamp>
+    <doi_batch_id>1682da4dbb979b88bf6c8c0e21003a86</doi_batch_id>
+    <timestamp>20171024135015</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>111</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.200268</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/111</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00111</item_number>
+          <identifier id_type="doi">10.21105/joss.00111</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.200268</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/111</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00111</doi>
-          <timestamp>20171023215159</timestamp>
+          <timestamp>20171024135015</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00111</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00111/10.21105.joss.00111.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Hunter, J. D., Matplotlib: A 2D graphics environment, Computing In Science & Engineering, 9, 3, 90–95, Matplotlib is a 2D graphics package used for Python for application development, interactive scripting, and publication-quality image generation across user interfaces and operating systems., IEEE COMPUTER SOC, 2007</unstructured_citation></citation><citation key="ref2"><unstructured_citation>C., Davidson-Pilon, Lifelines, 2016, GitHub, GitHub repository, \urlhttps://github.com/camdavidsonpilon/lifelines, latest_commit</unstructured_citation></citation><citation key="ref3"><unstructured_citation>McKinney, Wes, Data Structures for Statistical Computing in Python , Proceedings of the 9th Python in Science Conference , 51 - 56 , 2010 , van der Walt, Stéfan and Millman, Jarrod</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Jones, Eric and Oliphant, Travis and Peterson, Pearu and others, SciPy: Open source scientific tools for Python, 2001–, http://www.scipy.org/</unstructured_citation></citation><citation key="ref5"><doi>10.1109/MCSE.2007.53</doi></citation><citation key="ref6"><unstructured_citation>Vanderplas, Jake, mpld3: A D3 Viewer for Matplotlib, 2016, GitHub, GitHub repository, http://www.scipy.org/</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Machin, John, xlrd: a library to extract data from Microsoft Excel (tm) files, 2016, GitHub, GitHub repository, https://github.com/python-excel/xlrd</unstructured_citation></citation><citation key="ref8"><doi>10.1080/01621459.1958.10501452</doi></citation></citation_list>
       </journal_article>

--- a/joss.00116/10.21105.joss.00116.crossref.xml
+++ b/joss.00116/10.21105.joss.00116.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>9eaa44bfc86ff42d1fa4edf328e72ecf</doi_batch_id>
-    <timestamp>20171023215208</timestamp>
+    <doi_batch_id>d61254336465b13f2895c93ea42d2175</doi_batch_id>
+    <timestamp>20171024135017</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>116</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.167092</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/116</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00116</item_number>
+          <identifier id_type="doi">10.21105/joss.00116</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">https://dx.doi.org/10.5281/zenodo.167092</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/116</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00116</doi>
-          <timestamp>20171023215208</timestamp>
+          <timestamp>20171024135017</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00116</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00116/10.21105.joss.00116.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Warren, Rene L, RAILS and Cobbler: Scaffolding and automated finishing of draft genomes using long sequences, 2016, https://github.com/warrenlr/RAILS, 2016-11-10</unstructured_citation></citation><citation key="ref2"><doi>10.1093/nar/gkr1100</doi></citation><citation key="ref3"><doi>10.1186/s12859-015-0663-4</doi></citation><citation key="ref4"><doi>10.1186/gb-2010-11-4-r41</doi></citation><citation key="ref5"><doi>10.1186/gb-2012-13-6-r56</doi></citation><citation key="ref6"><doi>10.1186/s13742-015-0076-3</doi></citation><citation key="ref7"><doi>10.1093/bioinformatics/btl629</doi></citation></citation_list>
       </journal_article>

--- a/joss.00118/10.21105.joss.00118.crossref.xml
+++ b/joss.00118/10.21105.joss.00118.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>fb55eaf57f511f09b8bafa852834d3b2</doi_batch_id>
-    <timestamp>20171023215216</timestamp>
+    <doi_batch_id>bcc73977bc8a8420799004638699925b</doi_batch_id>
+    <timestamp>20171024135018</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>118</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4285097.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/118</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00118</item_number>
+          <identifier id_type="doi">10.21105/joss.00118</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4285097.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/118</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00118</doi>
-          <timestamp>20171023215216</timestamp>
+          <timestamp>20171024135018</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00118</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00118/10.21105.joss.00118.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1099/mgen.0.000083</doi></citation><citation key="ref2"><doi>10.1073/pnas.95.6.3140</doi></citation><citation key="ref3"><unstructured_citation>Seeman, Torsten, Scan contig files against PubMLST typing schemes, https://github.com/tseemann/mlst, 2016</unstructured_citation></citation><citation key="ref4"><doi>10.1016/j.tim.2003.08.006</doi></citation><citation key="ref5"><doi>10.1186/1471-2105-11-595</doi></citation></citation_list>
       </journal_article>

--- a/joss.00119/10.21105.joss.00119.crossref.xml
+++ b/joss.00119/10.21105.joss.00119.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f4b3f6256a59d42f09facce791b06ca9</doi_batch_id>
-    <timestamp>20171023215225</timestamp>
+    <doi_batch_id>7420d9686e9051c84cb1569b1523d113</doi_batch_id>
+    <timestamp>20171024135020</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>119</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.192466</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/119</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00119</item_number>
+          <identifier id_type="doi">10.21105/joss.00119</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.192466</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/119</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00119</doi>
-          <timestamp>20171023215225</timestamp>
+          <timestamp>20171024135020</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00119</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00119/10.21105.joss.00119.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>XBRL: Extraction of Business Financial Information from ’XBRL’ Documents, Bertolusso, Roberto and Kimmel, Marek, 2016, R package version 0.99.17, https://CRAN.R-project.org/package=XBRL</unstructured_citation></citation><citation key="ref3"><unstructured_citation>quantmod: Quantitative Finacial Modelling Framework, Ryan, Jeffrey A. and Ulrich, Joshua M. and Thielen, Wouter, 2016, R package version 0.4-7, https://CRAN.R-project.org/package=quantmod</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00125/10.21105.joss.00125.crossref.xml
+++ b/joss.00125/10.21105.joss.00125.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5ca51ef8998e0bc027e12f8b4ec0f374</doi_batch_id>
-    <timestamp>20171023215233</timestamp>
+    <doi_batch_id>b7817ac300b85912cbd230bd18064593</doi_batch_id>
+    <timestamp>20171024135022</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>125</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.192679</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/125</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00125</item_number>
+          <identifier id_type="doi">10.21105/joss.00125</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.192679</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/125</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00125</doi>
-          <timestamp>20171023215233</timestamp>
+          <timestamp>20171024135022</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00125</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00125/10.21105.joss.00125.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Smith, Julius O., Digital Audio Resampling Home Page, https://ccrma.stanford.edu/ jos/resample/, jan, 2002, 1</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Secret Rabbit Code (aka libsamplerate)(software), de Castro, Erik, 2005</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00133/10.21105.joss.00133.crossref.xml
+++ b/joss.00133/10.21105.joss.00133.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>716c517a5c9d03e72f274968dd692083</doi_batch_id>
-    <timestamp>20171023215241</timestamp>
+    <doi_batch_id>069c75a9e0efc5ddfff3829f8d958961</doi_batch_id>
+    <timestamp>20171024135023</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>133</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.224637</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/133</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00133</item_number>
+          <identifier id_type="doi">10.21105/joss.00133</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.224637</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/133</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00133</doi>
-          <timestamp>20171023215241</timestamp>
+          <timestamp>20171024135023</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00133</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00133/10.21105.joss.00133.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Schrodt, Philip A., 2016-10-23 21:47:51 +0000, 2016-10-23 21:47:55 +0000, Paper presented at the International Studies Association, Chicago, 21-24 February 2001, Automated Coding of International Event Data Using Sparse Parsing Techniques, 2001</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Gerner, Deborah J. and Schrodt, Philip A. and Yilmaz, Omur and Abu-Jabr, Rajaa, 2016-10-23 21:47:14 +0000, 2016-10-23 21:47:14 +0000, American Political Science Association, Boston, August 2002, Conflict and Mediation Event Observations (CAMEO): A New Event Data Framework for the Analysis of Foreign Policy Interactions, 2001</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00135/10.21105.joss.00135.crossref.xml
+++ b/joss.00135/10.21105.joss.00135.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7648b0855092b79ca6369ed02b6e89d4</doi_batch_id>
-    <timestamp>20171023215249</timestamp>
+    <doi_batch_id>feb0bb13157319034c6262dab838462e</doi_batch_id>
+    <timestamp>20171024135024</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>135</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.293835</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/135</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00135</item_number>
+          <identifier id_type="doi">10.21105/joss.00135</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.293835</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/135</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00135</doi>
-          <timestamp>20171023215249</timestamp>
+          <timestamp>20171024135024</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00135</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00135/10.21105.joss.00135.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.18637/jss.v064.i11</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>snow: Simple Network of Workstations, Tierney, Luke and Rossini, A. J. and Li, Na and Sevcikova, H., 2016, R package version 0.4-2, https://CRAN.R-project.org/package=snow</unstructured_citation></citation><citation key="ref4"><unstructured_citation>data.table: Extension of Data.frame, Dowle, M and Srinivasan, A and Short, T and with contributions from R Saporta, S Lianoglou and Antonyan, E, 2015, R package version 1.9.6, https://CRAN.R-project.org/package=data.table</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00137/10.21105.joss.00137.crossref.xml
+++ b/joss.00137/10.21105.joss.00137.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c308c03aa271507b1a54521168849d98</doi_batch_id>
-    <timestamp>20171023215258</timestamp>
+    <doi_batch_id>0d2541cbaf1c207f8a8a5f4a5ae17e1e</doi_batch_id>
+    <timestamp>20171024135026</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>137</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.232521</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/137</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00137</item_number>
+          <identifier id_type="doi">10.21105/joss.00137</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.232521</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/137</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00137</doi>
-          <timestamp>20171023215258</timestamp>
+          <timestamp>20171024135026</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00137</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00137/10.21105.joss.00137.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Chichilnisky, EJ, 2016-12-01 21:56:09 +0000, 2016-12-01 21:56:13 +0000, Network: Computation in Neural Systems, 2, 199–213, Taylor & Francis, A simple white noise analysis of neuronal light responses, 12, 2001</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Schwartz, Odelia and Pillow, Jonathan W and Rust, Nicole C and Simoncelli, Eero P, 2016-12-01 21:55:55 +0000, 2016-12-01 21:55:58 +0000, Journal of Vision, 4, 13–13, The Association for Research in Vision and Ophthalmology, Spike-triggered neural characterization, 6, 2006</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and others, 2016-12-01 21:54:40 +0000, 2016-12-01 21:54:49 +0000, Journal of Machine Learning Research, Oct, 2825–2830, Scikit-learn: Machine learning in Python, 12, 2011</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00139/10.21105.joss.00139.crossref.xml
+++ b/joss.00139/10.21105.joss.00139.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d10478178b04f437464e7602c4f11120</doi_batch_id>
-    <timestamp>20171023215308</timestamp>
+    <doi_batch_id>e07f93f117e9c4abb7b0d6c572a0cb0e</doi_batch_id>
+    <timestamp>20171024135027</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>139</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.228165</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/139</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00139</item_number>
+          <identifier id_type="doi">10.21105/joss.00139</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.228165</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/139</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00139</doi>
-          <timestamp>20171023215308</timestamp>
+          <timestamp>20171024135027</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00139</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00139/10.21105.joss.00139.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.47274</doi></citation></citation_list>
       </journal_article>

--- a/joss.00140/10.21105.joss.00140.crossref.xml
+++ b/joss.00140/10.21105.joss.00140.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c42d765d678963f849fc893ce442b1a3</doi_batch_id>
-    <timestamp>20171023215318</timestamp>
+    <doi_batch_id>e99d465df215a1025a2f47dcff8f1b9d</doi_batch_id>
+    <timestamp>20171024135028</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>140</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.297348</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/140</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00140</item_number>
+          <identifier id_type="doi">10.21105/joss.00140</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.297348</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/140</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00140</doi>
-          <timestamp>20171023215318</timestamp>
+          <timestamp>20171024135028</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00140</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00140/10.21105.joss.00140.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Parsons, Aaron, Astronomical Interferometry in Python, 2007, http://astro.berkeley.edu/ aparsons/aipy.pdf, https://casper.berkeley.edu/astrobaki/index.php/AIPY</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Greisen, Eric W., AIPS FITS File Format, AIPS Memo 117, National Radio Astronomy Observatory, AIPS has been writing images and uv data in FITS-format files for a very long time. While these files have been used widely in the community, there is a perception that a detailed document is still required. This memo is an attempt to meet that perception. AIPS FITS files for uv are conventions layered upon the standard FITS format to assist in the interchange of data recorded by interferometric telescopes, particularly by radio telescopes such as the EVLA and VLBA., radio astronomy, uvfits, feb, 2016, 107, ftp://ftp.aoc.nrao.edu/pub/software/aips/TEXT/PUBL/AIPSMEM117.PS, http://www.aips.nrao.edu/aipsmemo.html, 2</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Sault, R. J. and Teuben, P. J. and Wright, M. C. H., A Retrospective View of MIRIAD, Astronomical Data Analysis Software and Systems IV, Miriad is a radio interferometry data-reduction package, designed for taking raw data through to the image analysis stage. The Miriad project, begun in 1988, is now middle-aged. With the wisdom of hindsight, we review design decisions and some of Miriad’s characteristics., 1995, Astronomical Society of the Pacific Conference Series, 77, astro-ph/0612759, Shaw, R. A. and Payne, H. E. and Hayes, J. J. E., 433, http://adsabs.harvard.edu/abs/1995ASPC...77..433S, Provided by the SAO/NASA Astrophysics Data System, http://www.atnf.csiro.au/computing/software/miriad/</unstructured_citation></citation><citation key="ref4"><doi>10.1088/0004-637X/759/1/17</doi></citation></citation_list>
       </journal_article>

--- a/joss.00141/10.21105.joss.00141.crossref.xml
+++ b/joss.00141/10.21105.joss.00141.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>364ec56c2b69a93e7c56b3a62ce01716</doi_batch_id>
-    <timestamp>20171023215327</timestamp>
+    <doi_batch_id>e6b1bb8e8d0778292e40389ade50f64c</doi_batch_id>
+    <timestamp>20171024135029</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>141</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.209506</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/141</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00141</item_number>
+          <identifier id_type="doi">10.21105/joss.00141</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.209506</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/141</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00141</doi>
-          <timestamp>20171023215327</timestamp>
+          <timestamp>20171024135029</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00141</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00141/10.21105.joss.00141.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Variable Selection in the Functional Linear Concurrent Model, Under Review, Goldsmith, J and Schwartz, J E, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>refund.shiny: Interactive plotting for functional data analyses, Wrobel, J and Goldsmith, J, 2015, R package version 0.2</unstructured_citation></citation><citation key="ref3"><doi>10.1002/sta4.109</doi></citation></citation_list>
       </journal_article>

--- a/joss.00142/10.21105.joss.00142.crossref.xml
+++ b/joss.00142/10.21105.joss.00142.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>57a8c3ad53418ae4072192e351a34aab</doi_batch_id>
-    <timestamp>20171023215335</timestamp>
+    <doi_batch_id>1972c8b9115f9d45870a070a9829c6fd</doi_batch_id>
+    <timestamp>20171024135030</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>142</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.260437</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/142</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00142</item_number>
+          <identifier id_type="doi">10.21105/joss.00142</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.260437</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/142</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00142</doi>
-          <timestamp>20171023215335</timestamp>
+          <timestamp>20171024135030</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00142</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00142/10.21105.joss.00142.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1101/gr.113985.110</doi></citation><citation key="ref2"><doi>10.1371/journal.pgen.1004365</doi></citation><citation key="ref3"><doi>10.1016/S0022-2836(05)80360-2</doi></citation><citation key="ref4"><doi>10.5281/zenodo.16303</doi></citation><citation key="ref5"><doi>10.1016/j.cbpa.2003.12.004</doi></citation><citation key="ref6"><doi>10.1093/nar/gkr853</doi></citation></citation_list>
       </journal_article>

--- a/joss.00146/10.21105.joss.00146.crossref.xml
+++ b/joss.00146/10.21105.joss.00146.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a550e0137eeedb3bfbe25e05a512c004</doi_batch_id>
-    <timestamp>20171023215343</timestamp>
+    <doi_batch_id>79a299b4098286a8aa9487fc75572aa0</doi_batch_id>
+    <timestamp>20171024135031</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>146</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4868882</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/146</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00146</item_number>
+          <identifier id_type="doi">10.21105/joss.00146</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4868882</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/146</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00146</doi>
-          <timestamp>20171023215343</timestamp>
+          <timestamp>20171024135031</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00146</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00146/10.21105.joss.00146.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Elabftw: A Free and Open Source Electronic Laboratory Notebook, Nicolas CARPi, Elabftw, Paris, France, 2012, https://www.elabftw.net/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Elabftw official documentation, Nicolas CARPi, Elabftw, Paris, France, 2012, https://elabftw.readthedocs.io/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Elabftw online demo, Nicolas CARPi, Elabftw, Paris, France, 2012, https://demo.elabftw.net/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00151/10.21105.joss.00151.crossref.xml
+++ b/joss.00151/10.21105.joss.00151.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>13a142292060a5d1b6e68d144e066fe1</doi_batch_id>
-    <timestamp>20171023215352</timestamp>
+    <doi_batch_id>63a31e69ce300782100f970787e5a172</doi_batch_id>
+    <timestamp>20171024135033</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>151</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.570521</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/151</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00151</item_number>
+          <identifier id_type="doi">10.21105/joss.00151</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.570521</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/151</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00151</doi>
-          <timestamp>20171023215352</timestamp>
+          <timestamp>20171024135033</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00151</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00151/10.21105.joss.00151.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/DSD.2011.36</doi></citation><citation key="ref2"><doi>10.1109/IEEESTD.2014.6898803</doi></citation></citation_list>
       </journal_article>

--- a/joss.00153/10.21105.joss.00153.crossref.xml
+++ b/joss.00153/10.21105.joss.00153.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>904b15572b74ea0589e4a0f771bcb3a9</doi_batch_id>
-    <timestamp>20171023215401</timestamp>
+    <doi_batch_id>3df46b9938f7d379652aa0efa7b8da6b</doi_batch_id>
+    <timestamp>20171024135034</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>153</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.290628</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/153</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00153</item_number>
+          <identifier id_type="doi">10.21105/joss.00153</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.290628</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/153</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00153</doi>
-          <timestamp>20171023215401</timestamp>
+          <timestamp>20171024135034</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00153</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00153/10.21105.joss.00153.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/j.mri.2012.05.001</doi></citation><citation key="ref2"><doi>10.1109/ISBI.2016.7493437</doi></citation><citation key="ref3"><doi>10.1109/TBME.2014.2322864</doi></citation><citation key="ref4"><unstructured_citation>An Open Source, Fast Ultrasound B-Mode Implementation for Commodity Hardware, http://hdl.handle.net/10380/3159, 2016-12-13, Insight Journal, McCormick, Matthew M, 2010</unstructured_citation></citation><citation key="ref5"><doi>10.3389/fninf.2014.00013</doi></citation><citation key="ref6"><doi>10.1109/ULTSYM.2016.7728618</doi></citation><citation key="ref7"><unstructured_citation>Implementation and Algorithm Development of 3D ARFI and SWEI Imaging for in vivo Detection of Prostate Cancer, http://dukespace.lib.duke.edu/dspace/handle/10161/9062, 2016-12-13, Duke University, Rosenzweig, Stephen J., 2014</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00164/10.21105.joss.00164.crossref.xml
+++ b/joss.00164/10.21105.joss.00164.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>0112bb0acbb4c3fbc2163936b0639e6a</doi_batch_id>
-    <timestamp>20171023215410</timestamp>
+    <doi_batch_id>8fe806241f8e41425a7fa7edaeb2ccd7</doi_batch_id>
+    <timestamp>20171024135035</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>164</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.290299</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/164</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00164</item_number>
+          <identifier id_type="doi">10.21105/joss.00164</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.290299</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/164</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00164</doi>
-          <timestamp>20171023215410</timestamp>
+          <timestamp>20171024135035</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00164</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00164/10.21105.joss.00164.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/SC.Companion.2012.132</doi></citation><citation key="ref2"><doi>10.1007/978-1-4939-1905-5_15</doi></citation><citation key="ref3"><doi>10.1109/IC2E.2014.66</doi></citation><citation key="ref4"><unstructured_citation>Scalable state management for scientific applications in the cloud, Li, Tonglin and Raicu, Ioan and Ramakrishnan, Lavanya, 2014 IEEE International Congress on Big Data, 204–211, 2014, IEEE</unstructured_citation></citation><citation key="ref5"><unstructured_citation>FRIEDA, FRIEDA, 2016, http://frieda.lbl.gov, 2016-08-29</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00166/10.21105.joss.00166.crossref.xml
+++ b/joss.00166/10.21105.joss.00166.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b94f6fa203722f40f4c2010b80d02273</doi_batch_id>
-    <timestamp>20171023215418</timestamp>
+    <doi_batch_id>ec9db7d847addbb5f86ff95dc319098e</doi_batch_id>
+    <timestamp>20171024135036</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>166</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.438320</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/166</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00166</item_number>
+          <identifier id_type="doi">10.21105/joss.00166</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.438320</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/166</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00166</doi>
-          <timestamp>20171023215418</timestamp>
+          <timestamp>20171024135036</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00166</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00166/10.21105.joss.00166.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The Wiener–Askey polynomial chaos for stochastic differential equations, Xiu, Dongbin and Karniadakis, George Em, SIAM journal on scientific computing, 24, 2, 619–644, 2002, SIAM</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Sparse pseudospectral approximation method, Constantine, Paul G and Eldred, Michael S and Phipps, Eric T, Computer Methods in Applied Mechanics and Engineering, 229, 1–12, 2012, Elsevier</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Seshadri, Pranay, Effective-Quadratures, nov, 2016, https://github.com/Effective-Quadratures/Effective-Quadratures, 11</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Seshadri, P. and Narayan, A. and Mahadevan, S., Effectively Subsampled Quadratures For Least Squares Polynomial Approximations, ArXiv e-prints, arXiv, 1601.05470, math.NA, Mathematics - Numerical Analysis, Mathematics - Probability, 93E24, 41A55, 33C45, 2016, jan, http://adsabs.harvard.edu/abs/2016arXiv160105470S, Provided by the SAO/NASA Astrophysics Data System, 1</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00167/10.21105.joss.00167.crossref.xml
+++ b/joss.00167/10.21105.joss.00167.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e52564b6cfe9d1e685975dcf38208a66</doi_batch_id>
-    <timestamp>20171023215426</timestamp>
+    <doi_batch_id>a4b302a12d99128b5d30db9bd8c1ae13</doi_batch_id>
+    <timestamp>20171024135037</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>167</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.292939</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/167</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00167</item_number>
+          <identifier id_type="doi">10.21105/joss.00167</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.292939</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/167</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00167</doi>
-          <timestamp>20171023215426</timestamp>
+          <timestamp>20171024135037</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00167</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00167/10.21105.joss.00167.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1101/005033</doi></citation></citation_list>
       </journal_article>

--- a/joss.00168/10.21105.joss.00168.crossref.xml
+++ b/joss.00168/10.21105.joss.00168.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>99398a7c427152e3f0f99e574916e289</doi_batch_id>
-    <timestamp>20171023215435</timestamp>
+    <doi_batch_id>10cf1ec777440556e54601bba5a272a9</doi_batch_id>
+    <timestamp>20171024135039</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>168</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.268032</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/168</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00168</item_number>
+          <identifier id_type="doi">10.21105/joss.00168</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.268032</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/168</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00168</doi>
-          <timestamp>20171023215435</timestamp>
+          <timestamp>20171024135039</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00168</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00168/10.21105.joss.00168.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Group, The SAM/BAM Format Specification Working, Sequence Alignment/Map Format Specification, 2016, https://samtools.github.io/hts-specs/SAMv1.pdf, 2017-04-2</unstructured_citation></citation><citation key="ref2"><doi>10.1093/bioinformatics/btp352</doi></citation><citation key="ref3"><doi>10.1093/bioinformatics/btv098</doi></citation></citation_list>
       </journal_article>

--- a/joss.00169/10.21105.joss.00169.crossref.xml
+++ b/joss.00169/10.21105.joss.00169.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>1faa74cbedc02ca2e6bf8eb7d81d1fbf</doi_batch_id>
-    <timestamp>20171023215443</timestamp>
+    <doi_batch_id>23a01329674466f1442d09f026526fdd</doi_batch_id>
+    <timestamp>20171024135040</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>169</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.256850</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/169</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00169</item_number>
+          <identifier id_type="doi">10.21105/joss.00169</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.256850</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/169</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00169</doi>
-          <timestamp>20171023215443</timestamp>
+          <timestamp>20171024135040</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00169</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00169/10.21105.joss.00169.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>MacFarlane, John, Pandoc a universal document converter, 2007, http://pandoc.org, 2016-12-08</unstructured_citation></citation><citation key="ref2"><unstructured_citation>abnTeX, Classe LaTeX e estilo bibliográfico compatíveis com as normas da ABNT, 2016, http://www.abntex.net.br, 2016-12-08</unstructured_citation></citation><citation key="ref3"><unstructured_citation>YAML, YAML Ain’t Markup Language, 2001, http://yaml.org, 2016-12-08</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Foersom, Richard, Create PDF Forms with LibreOffice, 2016, http://foersom.com/org/HowTo/CreatePdfForm.html, 2016-12-08</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Rio de Janeiro, ABNT, Associação Brasileira de Normas Técnicas, 15, NBR 14724, 2011</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00170/10.21105.joss.00170.crossref.xml
+++ b/joss.00170/10.21105.joss.00170.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>60f6c10d2ab997ecfa613e5d8a48df1b</doi_batch_id>
-    <timestamp>20171023215452</timestamp>
+    <doi_batch_id>66553753c95959a945664d5461b20ab5</doi_batch_id>
+    <timestamp>20171024135041</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>170</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.268587</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/170</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00170</item_number>
+          <identifier id_type="doi">10.21105/joss.00170</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.268587</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/170</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00170</doi>
-          <timestamp>20171023215452</timestamp>
+          <timestamp>20171024135041</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00170</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00170/10.21105.joss.00170.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Kraljic, Peter, Purchasing must become supply management, Harvard Business Review, 1983, 61, 5, 109–117, https://hbr.org/1983/09/purchasing-must-become-supply-management</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Montgomery, Robert T. and Ogden, Jeffrey A. and Boehmke, Bradley C., A Quantified Kraljic Portfolio Matrix: Using Decision Analysis for Strategic Purchasing, Journal of Purchasing and Supply Management, 2017, forthcoming</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00171/10.21105.joss.00171.crossref.xml
+++ b/joss.00171/10.21105.joss.00171.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ece52304d69007dcc0783bf97bd21790</doi_batch_id>
-    <timestamp>20171023215500</timestamp>
+    <doi_batch_id>53e23256cc04c14f7120d29a4ac08f55</doi_batch_id>
+    <timestamp>20171024135042</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>171</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.267972</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/171</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00171</item_number>
+          <identifier id_type="doi">10.21105/joss.00171</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.267972</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/171</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00171</doi>
-          <timestamp>20171023215500</timestamp>
+          <timestamp>20171024135042</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00171</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00171/10.21105.joss.00171.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3905/JPM.2008.35.1.40</doi></citation><citation key="ref2"><doi>10.21314/JOIS.2013.033</doi></citation><citation key="ref3"><doi>10.3905/jpm.2012.38.3.056</doi></citation><citation key="ref4"><doi>10.3905/jpm.2010.36.4.060</doi></citation><citation key="ref5"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, http://www.R-project.org/</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Amenc, Noel and Goltz, Felix and Martellini, Lionel and Retkowsky, Patrice, Efficient Indexation: An alternative to cap-weighted indices, Journal of Investment Management, 2011, 9, 4, 1–23, Administrator, 2013.01.15</unstructured_citation></citation><citation key="ref7"><unstructured_citation>quadprog: Functions to solve Quadratic Programming Problems, Weingessel, Andreas, 2013, R package version 1.5-5, https://cran.r-project.org/package=quadprog</unstructured_citation></citation><citation key="ref8"><unstructured_citation>nloptr: R interface to NLopt, Ypma, Jelmer, 2014, R package version 1.0.4, https://cran.r-project.org/package=nloptr</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Ardia, David and Bolliger, Guido and Boudt, Kris and Gagnon-Fleury, Jean-Philippe, The impact of covariance misspecification in risk-based portfolios, 2016, Working paper</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00172/10.21105.joss.00172.crossref.xml
+++ b/joss.00172/10.21105.joss.00172.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>cd6debafb5660f57105cbdbdf855eb24</doi_batch_id>
-    <timestamp>20171023215509</timestamp>
+    <doi_batch_id>d295711dc4900d9a2194406918b26ec8</doi_batch_id>
+    <timestamp>20171024135043</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>172</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.268594</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/172</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00172</item_number>
+          <identifier id_type="doi">10.21105/joss.00172</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.268594</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/172</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00172</doi>
-          <timestamp>20171023215509</timestamp>
+          <timestamp>20171024135043</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00172</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00172/10.21105.joss.00172.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, http://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><doi>10.1214/ss/1177011137</doi></citation><citation key="ref3"><doi>10.1145/358598.358630</doi></citation><citation key="ref4"><doi>10.1214/09-aos735</doi></citation><citation key="ref5"><doi>10.3386/t0144</doi></citation><citation key="ref6"><doi>10.2307/1913610</doi></citation><citation key="ref7"><doi>10.1017/s0266466609990089</doi></citation><citation key="ref8"><doi>10.2307/2951574</doi></citation><citation key="ref9"><unstructured_citation>Politis, Dimitris N and Romano, Joseph P, A Circular Block-resampling Procedure for Stationary Data, Exploring the Limits of Bootstrap, John Wiley & Sons, 1992, 263–270, [bluteauk:1], Exploring the limits of bootstrap</unstructured_citation></citation><citation key="ref10"><doi>10.2307/2290993</doi></citation><citation key="ref11"><doi>10.1081/etc-120028836</doi></citation><citation key="ref12"><doi>10.2307/2938229</doi></citation><citation key="ref13"><unstructured_citation>Ardia, D. and Bluteau, K. and Hoogerheide, Lennart F., Comparison of multiple methods for computing numerical standard errors: An extensive Monte Carlo study, 2016, Working paper, https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2741587</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00176/10.21105.joss.00176.crossref.xml
+++ b/joss.00176/10.21105.joss.00176.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>8aa0afa8dbceebbcd5c0e3241cdf8e89</doi_batch_id>
-    <timestamp>20171023215517</timestamp>
+    <doi_batch_id>4a74aed1139fd7e0db38b444bf52f113</doi_batch_id>
+    <timestamp>20171024135045</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>176</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4684894</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/176</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00176</item_number>
+          <identifier id_type="doi">10.21105/joss.00176</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4684894</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/176</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00176</doi>
-          <timestamp>20171023215517</timestamp>
+          <timestamp>20171024135045</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00176</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00176/10.21105.joss.00176.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1002/rse2.11</doi></citation><citation key="ref2"><doi>10.1007/s13364-011-0055-8</doi></citation><citation key="ref3"><doi>http://dx.doi.org/10.1016/j.mambio.2009.08.005</doi></citation><citation key="ref4"><doi>10.1111/j.1365-2664.2008.01473.x</doi></citation></citation_list>
       </journal_article>

--- a/joss.00177/10.21105.joss.00177.crossref.xml
+++ b/joss.00177/10.21105.joss.00177.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>fc27198e7935b5f45bc40afd7da3d4b3</doi_batch_id>
-    <timestamp>20171023215525</timestamp>
+    <doi_batch_id>3bb0b161ab4467ac75b44d82a58d8e90</doi_batch_id>
+    <timestamp>20171024135046</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>177</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.260229</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/177</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00177</item_number>
+          <identifier id_type="doi">10.21105/joss.00177</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.260229</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/177</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00177</doi>
-          <timestamp>20171023215525</timestamp>
+          <timestamp>20171024135046</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00177</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00177/10.21105.joss.00177.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>United States National Oceanic and Atmospheric Administration National Climatic Data Center, Global Surface Summary of Day (GSOD), aug, 2016, \urlhttps://data.noaa.gov/dataset/global-surface-summary-of-the-day-gsod, 10/08/2016, 8</unstructured_citation></citation><citation key="ref3"><unstructured_citation>rnoaa: ’NOAA’ Weather Data from R, Chamberlain, Scott, 2016, R package version 0.5.6, https://CRAN.R-project.org/package=rnoaa</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Hole-filled SRTM for the globe Version 4, available from the CGIAR-CSI SRTM 90m Database, Jarvis, Andy and Reuter, Hannes I and Nelson, Andy and Guevara, Edward, 2008, http://srtm.csi.cgiar.org</unstructured_citation></citation><citation key="ref5"><unstructured_citation>GSODR: Global Summary Daily Weather Data in R, Sparks, Adam and Hengl, Tomislav and Nelson, Andrew, 2017, R package version 1.0.1, http://ropensci.github.io/GSODR/</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Open Geospatial Consortium, GeoPackage Encoding Standard, http://www.opengeospatial.org/standards/geopackage, 2014</unstructured_citation></citation><citation key="ref7"><unstructured_citation>readr: Read Tabular Data, Wickham, Hadley and Hester, Jim and Francois, Romain, 2016, R package version 1.0.0, https://CRAN.R-project.org/package=readr</unstructured_citation></citation><citation key="ref8"><unstructured_citation>data.table: Extension of Data.frame, Dowle, M and Srinivasan, A and Short, T and with contributions from R Saporta, S Lianoglou and Antonyan, E, 2015, R package version 1.9.6, https://CRAN.R-project.org/package=data.table</unstructured_citation></citation><citation key="ref9"><unstructured_citation>The Split-Apply-Combine Strategy for Data Analysis, Wickham, Hadley, Journal of Statistical Software, 2011, 40, 1, 1–29, http://www.jstatsoft.org/v40/i01/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00179/10.21105.joss.00179.crossref.xml
+++ b/joss.00179/10.21105.joss.00179.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7d123f2e4cc2fbc274f2e7aeb1261c1e</doi_batch_id>
-    <timestamp>20171023215533</timestamp>
+    <doi_batch_id>5d46ce60887d2f96f230c17c051ddaff</doi_batch_id>
+    <timestamp>20171024135047</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>179</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.375807</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/179</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00179</item_number>
+          <identifier id_type="doi">10.21105/joss.00179</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.375807</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/179</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00179</doi>
-          <timestamp>20171023215533</timestamp>
+          <timestamp>20171024135047</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00179</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00179/10.21105.joss.00179.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Niskanen, J. and Salmela, E. and Lohi, H., AncesTrim - a tool for trimming complex pedigrees, 2017, https://github.com/JNisk/AncesTrim, 2017-01-03</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00182/10.21105.joss.00182.crossref.xml
+++ b/joss.00182/10.21105.joss.00182.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5a7e3d0ecbd66cee31455f90dcfb4b7e</doi_batch_id>
-    <timestamp>20171023215542</timestamp>
+    <doi_batch_id>769b6546694b0721f1cc109b76b1d5bd</doi_batch_id>
+    <timestamp>20171024135048</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>182</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.345982</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/182</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00182</item_number>
+          <identifier id_type="doi">10.21105/joss.00182</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.345982</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/182</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00182</doi>
-          <timestamp>20171023215542</timestamp>
+          <timestamp>20171024135048</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00182</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00182/10.21105.joss.00182.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1051/0004-6361:20041729</doi></citation><citation key="ref2"><doi>10.1016/j.jqsrt.2013.07.002</doi></citation><citation key="ref3"><doi>10.1051/0004-6361/201015333</doi></citation><citation key="ref4"><doi>10.1086/424439</doi></citation><citation key="ref5"><unstructured_citation>Crovisier, J. and Encrenaz, T., Infrared fluorescence of molecules in comets - The general synthetic spectrum, \aap, Abundance, Comets, Infrared Spectra, Molecular Spectra, Resonance Fluorescence, Cometary Atmospheres, Cosmochemistry, Data Simulation, Molecular Excitation, Solar Radiation, Vibrational Spectra, 1983, sep, 126, 170-182, http://adsabs.harvard.edu/abs/1983A%26A...126..170C, Provided by the SAO/NASA Astrophysics Data System, 9</unstructured_citation></citation><citation key="ref6"><unstructured_citation>de Val-Borro, M., CINE on GitHub, 2017, https://github.com/migueldvb/cine, 2017-02-01</unstructured_citation></citation><citation key="ref7"><doi>10.5281/zenodo.160246</doi></citation><citation key="ref8"><unstructured_citation>de Val-Borro, M. and Wilson, T. G., CRETE: Comet RadiativE Transfer and Excitation, Software , Astrophysics Source Code Library, 2016, dec, ascl, 1612.009, http://adsabs.harvard.edu/abs/2016ascl.soft12009D, Provided by the SAO/NASA Astrophysics Data System, 12</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00188/10.21105.joss.00188.crossref.xml
+++ b/joss.00188/10.21105.joss.00188.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>2093e001c8259325aef1d40155b4bbb9</doi_batch_id>
-    <timestamp>20171023215551</timestamp>
+    <doi_batch_id>fc4687018706acc930652749b86b5128</doi_batch_id>
+    <timestamp>20171024135049</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>188</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.439774</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/188</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00188</item_number>
+          <identifier id_type="doi">10.21105/joss.00188</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.439774</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/188</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00188</doi>
-          <timestamp>20171023215551</timestamp>
+          <timestamp>20171024135049</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00188</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00188/10.21105.joss.00188.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Scikit-learn: Machine Learning in Python, Pedregosa, F. and Varoquaux, G. and Gramfort, A. and Michel, V. and Thirion, B. and Grisel, O. and Blondel, M. and Prettenhofer, P. and Weiss, R. and Dubourg, V. and Vanderplas, J. and Passos, A. and Cournapeau, D. and Brucher, M. and Perrot, M. and Duchesnay, E., Journal of Machine Learning Research, 12, 2825–2830, 2011</unstructured_citation></citation><citation key="ref2"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref3"><unstructured_citation>Humphrey, William and Dalke, Andrew and Schulten, Klaus, VMD – Visual Molecular Dynamics, Journal of Molecular Graphics, 1996, 14, 33-38, , Published., , 222</unstructured_citation></citation><citation key="ref4"><unstructured_citation>PyMOL The PyMOL Molecular Graphics System, Version 1.8, Schrödinger, LLC., Schrödinger, LLC, 2010-08-19 17:29:55 -0400, 2015-12-22 18:04:08 -0400, nov, The PyMOL Molecular Graphics System, Version 1.8, 2015, 11</unstructured_citation></citation><citation key="ref5"><doi>10.21105/joss.00024</doi></citation><citation key="ref6"><doi>10.5281/zenodo.54844</doi></citation><citation key="ref7"><unstructured_citation>Hagberg, Aric A. and Schult, Daniel A. and Swart, Pieter J., Exploring network structure, dynamics, and function using NetworkX, 2008, aug, http://math.lanl.gov/ hagberg/Papers/hagberg-2008-exploring.pdf, Proceedings of the 7th Python in Science Conference (SciPy2008), Gäel Varoquaux, Travis Vaught, and Jarrod Millman, Pasadena, CA USA, 11–15, 8</unstructured_citation></citation><citation key="ref8"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref9"><doi>10.1016/j.bpj.2016.10.042</doi></citation><citation key="ref10"><doi>10.5281/zenodo.162942</doi></citation></citation_list>
       </journal_article>

--- a/joss.00189/10.21105.joss.00189.crossref.xml
+++ b/joss.00189/10.21105.joss.00189.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ad40adb0ef42ec998daa5085434edbf5</doi_batch_id>
-    <timestamp>20171023215600</timestamp>
+    <doi_batch_id>dd46b1cf1fedf71e84fd714d15813d4b</doi_batch_id>
+    <timestamp>20171024135050</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>189</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.322453</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/189</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00189</item_number>
+          <identifier id_type="doi">10.21105/joss.00189</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.322453</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/189</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00189</doi>
-          <timestamp>20171023215600</timestamp>
+          <timestamp>20171024135050</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00189</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00189/10.21105.joss.00189.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Elliptic Fourier features of a closed contour, Kuhl, Frank P and Giardina, Charles R, Computer graphics and image processing, 18, 3, 236–258, 1982, Elsevier</unstructured_citation></citation><citation key="ref2"><unstructured_citation>2-D particle shape averaging and comparison using Fourier descriptors, Raj, P Markondeya and Cannon, W Roger, Powder technology, 104, 2, 180–189, 1999, Elsevier</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Quantitative evaluation of Tarocco sweet orange fruit shape using optoelectronic elliptic Fourier based analysis, Costa, Corrado and Menesatti, Paolo and Paglia, Graziella and Pallottino, Federico and Aguzzi, Jacopo and Rimatori, Valentina and Russo, Giuseppe and Recupero, Santo and Recupero, Giuseppe Reforgiato, Postharvest biology and Technology, 54, 1, 38–47, 2009, Elsevier</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Blidh, Henrik, Python implementation of Elliptic Fourier Features of a Closed Contour, 2013, https://github.com/hbldh/pyefd, 2017-02-23</unstructured_citation></citation><citation key="ref5"><doi>10.1109/MCSE.2007.55</doi></citation></citation_list>
       </journal_article>

--- a/joss.00190/10.21105.joss.00190.crossref.xml
+++ b/joss.00190/10.21105.joss.00190.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5f371316b83254a394c2034c8f8998ff</doi_batch_id>
-    <timestamp>20171023215609</timestamp>
+    <doi_batch_id>1f377e0f5d904ca053b04e71771db70a</doi_batch_id>
+    <timestamp>20171024135051</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>190</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.344900</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/190</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00190</item_number>
+          <identifier id_type="doi">10.21105/joss.00190</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.344900</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/190</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00190</doi>
-          <timestamp>20171023215609</timestamp>
+          <timestamp>20171024135051</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00190</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00190/10.21105.joss.00190.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Crabtree, Charles and Nelson, Michael J., 2017-03-05 15:25:17 +0000, 2017-03-05 15:25:56 +0000, International Studies Quarterly, New Evidence for a Positive Relationship Between De Facto Judicial Independence and State Respect for Empowerment Rights, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Tukey, John W., 2017-03-05 15:23:42 +0000, 2017-03-05 15:24:07 +0000, Pearson, Exploratory Data Analysis, 1977</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Trochim, William M. K. and Donnelly, James P., 2017-03-05 15:22:58 +0000, 2017-03-05 15:23:40 +0000, Cengage Learning, Research Methods Knowledge Base, 2008</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00194/10.21105.joss.00194.crossref.xml
+++ b/joss.00194/10.21105.joss.00194.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c3cdb5b7bae3bf72625490c2ae5a9ece</doi_batch_id>
-    <timestamp>20171023215617</timestamp>
+    <doi_batch_id>77b63cc754a9365661781c1d74f25733</doi_batch_id>
+    <timestamp>20171024135053</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>194</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.345991</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/194</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00194</item_number>
+          <identifier id_type="doi">10.21105/joss.00194</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.345991</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/194</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00194</doi>
-          <timestamp>20171023215617</timestamp>
+          <timestamp>20171024135053</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00194</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00194/10.21105.joss.00194.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Herlocker, Morgan, Turf: Advanced geospatial analysis for browsers and node, 2016, http://turfjs.org/, 2016-12-16</unstructured_citation></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Bivand, Roger S and Pebesma, Edzer and Gómez-Rubio, Virgilio, Applied Spatial Data Analysis with R, 2013, Springer, 2</unstructured_citation></citation><citation key="ref4"><unstructured_citation>rgeos: Interface to Geometry Engine - Open Source (GEOS), Bivand, Roger S. and Rundel, C., 2016, R package version 0.3-19, https://CRAN.R-project.org/package=rgeos</unstructured_citation></citation><citation key="ref5"><unstructured_citation>GDAL - Geospatial Data Abstraction Library, Version 1.11.3, GDAL Development Team, Open Source Geospatial Foundation, 2015, http://www.gdal.org</unstructured_citation></citation><citation key="ref6"><unstructured_citation>GEOS - Geometry Engine, Open Source, Team, GEOS Development, Open Source Geospatial Foundation, 2016, https://trac.osgeo.org/geos/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00202/10.21105.joss.00202.crossref.xml
+++ b/joss.00202/10.21105.joss.00202.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>855f8d44ef847e85f800b18edfd80727</doi_batch_id>
-    <timestamp>20171023215627</timestamp>
+    <doi_batch_id>a4ad0bccca1189b900e7a428a58e22d0</doi_batch_id>
+    <timestamp>20171024135054</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>202</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.570062</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/202</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00202</item_number>
+          <identifier id_type="doi">10.21105/joss.00202</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.570062</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/202</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00202</doi>
-          <timestamp>20171023215627</timestamp>
+          <timestamp>20171024135054</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00202</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00202/10.21105.joss.00202.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Wright, T.P., Factors affecting the cost of airplanes, Journal of Aeronautical Sciences, 1936, 3, 4, 122–128, http://arc.aiaa.org/doi/abs/10.2514/8.155</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Crawford, J.R., Learning curve, ship curve, ratios, related data, Lockheed Aircraft Corporation, 1944, 122–128</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00204/10.21105.joss.00204.crossref.xml
+++ b/joss.00204/10.21105.joss.00204.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>2f9028485d841bb07c6a92a426cdf780</doi_batch_id>
-    <timestamp>20171023215636</timestamp>
+    <doi_batch_id>59cfa6d7f741dea3fb2419168df3ca39</doi_batch_id>
+    <timestamp>20171024135055</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>204</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.398871</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/204</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00204</item_number>
+          <identifier id_type="doi">10.21105/joss.00204</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.398871</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/204</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00204</doi>
-          <timestamp>20171023215636</timestamp>
+          <timestamp>20171024135055</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00204</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00204/10.21105.joss.00204.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1137/141000671</doi></citation><citation key="ref2"><unstructured_citation>Dynamic Documents with R and knitr, Xie, Yihui, Chapman and Hall/CRC, Boca Raton, Florida, 2015, 2nd, ISBN 978-1498716963, http://yihui.name/knitr/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00205/10.21105.joss.00205.crossref.xml
+++ b/joss.00205/10.21105.joss.00205.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c33bcccd514916572f3f7765b2ee90e8</doi_batch_id>
-    <timestamp>20171023215644</timestamp>
+    <doi_batch_id>4b41c3b4a2a77907aaf39892ce0e660e</doi_batch_id>
+    <timestamp>20171024135056</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>205</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.401403</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/205</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00205</item_number>
+          <identifier id_type="doi">10.21105/joss.00205</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.401403</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/205</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00205</doi>
-          <timestamp>20171023215644</timestamp>
+          <timestamp>20171024135056</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00205</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00205/10.21105.joss.00205.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1007/978-3-642-37456-2_14</doi></citation><citation key="ref2"><doi>10.1145/2733381</doi></citation><citation key="ref3"><doi>10.1109/TIT.2014.2361055</doi></citation><citation key="ref4"><unstructured_citation>Chaudhuri, Kamalika and Dasgupta, Sanjoy, Rates of Convergence for the Cluster Tree, Proceedings of the 23rd International Conference on Neural Information Processing Systems, NIPS’10, 2010, Vancouver, British Columbia, Canada, 343–351, 9, https://papers.nips.cc/paper/4068-rates-of-convergence-for-the-cluster-tree, 2997228, Curran Associates Inc., USA</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00207/10.21105.joss.00207.crossref.xml
+++ b/joss.00207/10.21105.joss.00207.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>35d5080ed9934d05b399959f4924126e</doi_batch_id>
-    <timestamp>20171023215653</timestamp>
+    <doi_batch_id>f5c642930faca839fc7fd5a919784ac9</doi_batch_id>
+    <timestamp>20171024135057</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>207</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4887398.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/207</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00207</item_number>
+          <identifier id_type="doi">10.21105/joss.00207</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4887398.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/207</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00207</doi>
-          <timestamp>20171023215653</timestamp>
+          <timestamp>20171024135057</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00207</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00207/10.21105.joss.00207.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Practical implementation of nonlinear time series methods: The TISEAN package, Hegger, Rainer, Holger Kantz and Schreiber, Thomas, Chaos: An Interdisciplinary Journal of Nonlinear Science, 9.2, 413-435, 1999</unstructured_citation></citation><citation key="ref2"><doi>10.5281/zenodo.376663</doi></citation><citation key="ref3"><unstructured_citation>Scikit-learn: Machine learning in Python, Pedregosa, Fabian and Varoquaux, Gaél and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and others, The Journal of Machine Learning Research, 12, 2825–2830, 2011, JMLR. org</unstructured_citation></citation><citation key="ref4"><unstructured_citation>API design for machine learning software: experiences from the scikit-learn project, Buitinck, Lars and Louppe, Gilles and Blondel, Mathieu and Pedregosa, Fabian and Mueller, Andreas and Grisel, Olivier and Niculae, Vlad and Prettenhofer, Peter and Gramfort, Alexandre and Grobler, Jaques and others, arXiv preprint arXiv:1309.0238, 2013</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Jones, Eric and Oliphant, Travis and Peterson, Pearu and others, SciPy: Open source scientific tools for Python, 2001–, http://www.scipy.org/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00208/10.21105.joss.00208.crossref.xml
+++ b/joss.00208/10.21105.joss.00208.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>993d2243e38fefe8b3796e3c85fdfb41</doi_batch_id>
-    <timestamp>20171023215702</timestamp>
+    <doi_batch_id>c487cad9845177025b812e547d828234</doi_batch_id>
+    <timestamp>20171024135059</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>208</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4763857</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/208</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00208</item_number>
+          <identifier id_type="doi">10.21105/joss.00208</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4763857</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/208</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00208</doi>
-          <timestamp>20171023215702</timestamp>
+          <timestamp>20171024135059</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00208</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00208/10.21105.joss.00208.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1093/comjnl/bxw102</doi></citation><citation key="ref2"><unstructured_citation>Using Docker to support reproducible research, Chamberlain, Ryan and Invenshure, L and Schommer, Jennifer, 2014, josh, 2016.03.21, http://dx.doi.org/10.6084/m9.figshare.1101910</unstructured_citation></citation><citation key="ref3"><unstructured_citation>An Updated Performance Comparison of Virtual Machines and Linux Containers, Felter, Wes and Ferreira, Alexandre and Rajamony, Ram and Rubio, Juan, technology, 2014, 32, 28, u1056048, 2015.02.05</unstructured_citation></citation><citation key="ref4"><doi>10.1109/CLUSTR.2007.4629220</doi></citation></citation_list>
       </journal_article>

--- a/joss.00209/10.21105.joss.00209.crossref.xml
+++ b/joss.00209/10.21105.joss.00209.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>3a60631ca5507819528ee4505e5a4df3</doi_batch_id>
-    <timestamp>20171023215711</timestamp>
+    <doi_batch_id>a1daf8e2304d71ec57be0cc0f0ff5a53</doi_batch_id>
+    <timestamp>20171024135100</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>209</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.438282</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/209</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00209</item_number>
+          <identifier id_type="doi">10.21105/joss.00209</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.438282</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/209</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00209</doi>
-          <timestamp>20171023215711</timestamp>
+          <timestamp>20171024135100</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00209</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00209/10.21105.joss.00209.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1017/s0956796800000411</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00215/10.21105.joss.00215.crossref.xml
+++ b/joss.00215/10.21105.joss.00215.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b27899b2f15d8735a08ce448d5d2450a</doi_batch_id>
-    <timestamp>20171023215720</timestamp>
+    <doi_batch_id>6a8a6c0aa32b0bdb2c1720c11c4014f4</doi_batch_id>
+    <timestamp>20171024135101</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>215</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.557105</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/215</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00215</item_number>
+          <identifier id_type="doi">10.21105/joss.00215</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.557105</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/215</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00215</doi>
-          <timestamp>20171023215720</timestamp>
+          <timestamp>20171024135101</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00215</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00215/10.21105.joss.00215.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/j.physrep.2010.11.002</doi></citation><citation key="ref2"><doi>10.1080/01944361003766766</doi></citation><citation key="ref3"><unstructured_citation>Cham, Switzerland, Lecture Notes in Geoinformation and Cartography, OpenStreetMap in GIScience, 978-3-319-14279-1, Springer International, Jokar Arsanjani, Jamal and Zipf, Alexander and Mooney, Peter and Helbich, Marco, 2015</unstructured_citation></citation><citation key="ref4"><doi>10.1068/b32045</doi></citation><citation key="ref5"><unstructured_citation>Oxford, England, Networks: An Introduction, 978-0-19-920665-0, Networks, English, Oxford University Press, Newman, M. E. J., may, 2010, 5</unstructured_citation></citation><citation key="ref6"><doi>10.1103/PhysRevE.73.036125</doi></citation><citation key="ref7"><doi>10.1068/b130131p</doi></citation><citation key="ref8"><doi>10.1038/sdata.2016.46</doi></citation><citation key="ref9"><doi>10.1068/b38216</doi></citation><citation key="ref10"><doi>10.1016/S0169-7552(98)00110-X</doi></citation></citation_list>
       </journal_article>

--- a/joss.00221/10.21105.joss.00221.crossref.xml
+++ b/joss.00221/10.21105.joss.00221.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>0ae271693cca8e1855a6f15a3b8880e5</doi_batch_id>
-    <timestamp>20171023215729</timestamp>
+    <doi_batch_id>35575b0aec59ba08b444b62c5a63532b</doi_batch_id>
+    <timestamp>20171024135103</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>221</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.572276</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/221</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00221</item_number>
+          <identifier id_type="doi">10.21105/joss.00221</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.572276</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/221</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00221</doi>
-          <timestamp>20171023215729</timestamp>
+          <timestamp>20171024135103</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00221</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00221/10.21105.joss.00221.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The GTK+ Project, https://www.gtk.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Gnome Developer, https://developer.gnome.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Glade - A User Interface Designer, https://glade.gnome.org/</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Campbell, P. S. and Stokke, A., Hook-content formulae for symplectic and orthogonal tableaux, ArXiv e-prints, arXiv, 0710.4155, math.CO, Mathematics - Combinatorics, Mathematics - Representation Theory, 05E15, 2007, oct, http://adsabs.harvard.edu/abs/2007arXiv0710.4155C, Provided by the SAO/NASA Astrophysics Data System, 10</unstructured_citation></citation><citation key="ref5"><unstructured_citation>YoungTab, https://github.com/luk87/YoungTab</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00222/10.21105.joss.00222.crossref.xml
+++ b/joss.00222/10.21105.joss.00222.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>43372c947a4b3b340966d676f4ae060a</doi_batch_id>
-    <timestamp>20171023215737</timestamp>
+    <doi_batch_id>dd2830f44b1bf4cdf752cea4c45086a1</doi_batch_id>
+    <timestamp>20171024135104</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>222</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.570875</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/222</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00222</item_number>
+          <identifier id_type="doi">10.21105/joss.00222</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.570875</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/222</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00222</doi>
-          <timestamp>20171023215737</timestamp>
+          <timestamp>20171024135104</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00222</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00222/10.21105.joss.00222.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>2017-05-02 17:37:11 +0000, 2017-05-02 17:37:11 +0000, SAO/NASA Astrophysics Data System, http://adsabs.harvard.edu, http://adsabs.harvard.edu</unstructured_citation></citation><citation key="ref2"><unstructured_citation>2017-05-02 17:37:10 +0000, 2017-05-02 17:37:52 +0000, High-Energy Physics Literature Database, http://inspirehep.net, http://adsabs.harvard.edu</unstructured_citation></citation><citation key="ref3"><unstructured_citation>2017-05-02 17:36:30 +0000, 2017-05-02 17:39:11 +0000, Cocoa TeX previewer for macOS, http://pages.uoregon.edu/koch/texshop</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00224/10.21105.joss.00224.crossref.xml
+++ b/joss.00224/10.21105.joss.00224.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>62da9159b06bc939c9aa0a008a91a148</doi_batch_id>
-    <timestamp>20171023215745</timestamp>
+    <doi_batch_id>1eea2b4b32fa527164b44a0af9af1b15</doi_batch_id>
+    <timestamp>20171024135105</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>224</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.801552</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/224</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00224</item_number>
+          <identifier id_type="doi">10.21105/joss.00224</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.801552</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/224</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00224</doi>
-          <timestamp>20171023215745</timestamp>
+          <timestamp>20171024135105</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00224</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00224/10.21105.joss.00224.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>cbcbeat, cbcbeat: an adjoint-enabled framework for computational cardiac electrophysiology, 2017, https://bitbucket.org/meg/cbcbeat, 2017-03-29</unstructured_citation></citation><citation key="ref2"><doi>10.1007/978-3-642-23099-8</doi></citation><citation key="ref3"><doi>10.1137/120873558</doi></citation><citation key="ref4"><unstructured_citation>Sundnes, Joakim and Lines, Glenn Terje and Cai, Xing and Nielsen, Bjørn Fredrik and Mardal, Kent-Andre and Tveito, Aslak, Computing the electrical activity in the heart, 2006, This book describes mathematical models and numerical techniques for simulating the electrical activity in the heart. The book gives an introduction to the most important models of the field, followed by a detailed description of numerical techniques for the models. Particular focus is on efficient numerical methods for large scale simulations on both scalar and parallel computers. The results presented in the book will be of particular interest to researchers in bioengineering and computational biology, who face the challenge of solving these complex mathematical models efficiently. The book will also serve as a valuable introduction to a new and exciting field for computational scientists and applied mathematicians., Springer-Verlag, 3-540-33432-7</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00230/10.21105.joss.00230.crossref.xml
+++ b/joss.00230/10.21105.joss.00230.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>bac05773c7254b6c61cea9948774eaaf</doi_batch_id>
-    <timestamp>20171023215754</timestamp>
+    <doi_batch_id>b5416d5537b132f8f2b7e6d9c4b2c442</doi_batch_id>
+    <timestamp>20171024135107</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>230</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.466812</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/230</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00230</item_number>
+          <identifier id_type="doi">10.21105/joss.00230</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.466812</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/230</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00230</doi>
-          <timestamp>20171023215754</timestamp>
+          <timestamp>20171024135107</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00230</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00230/10.21105.joss.00230.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3354/cr021001</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>raster: Geographic Data Analysis and Modeling, Hijmans, Robert J., 2016, R package version 2.5-8, https://CRAN.R-project.org/package=raster</unstructured_citation></citation><citation key="ref4"><doi>10.18637/jss.v059.i10</doi></citation><citation key="ref5"><unstructured_citation>tibble: Simple Data Frames, Wickham, Hadley and Francois, Romain and Müller, Kirill, 2017, R package version 1.3.0, https://CRAN.R-project.org/package=tibble</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00231/10.21105.joss.00231.crossref.xml
+++ b/joss.00231/10.21105.joss.00231.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f202146cb338ea286f6fa5a71081d421</doi_batch_id>
-    <timestamp>20171023215803</timestamp>
+    <doi_batch_id>f72ead8d5c0f7e7603f000572bf8fd8f</doi_batch_id>
+    <timestamp>20171024135108</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>231</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.573580</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/231</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00231</item_number>
+          <identifier id_type="doi">10.21105/joss.00231</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.573580</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/231</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00231</doi>
-          <timestamp>20171023215803</timestamp>
+          <timestamp>20171024135108</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00231</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00231/10.21105.joss.00231.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5210/OJPHI.V7I1.5677</doi></citation><citation key="ref2"><unstructured_citation>Bostock, Mike, d3: Data-Driven Documents, 2016, https://github.com/d3/d3, 2017-01-11</unstructured_citation></citation><citation key="ref3"><unstructured_citation>undefx, delphi-epidata: Documentation and sample code for DELPHI’s epidemiological data API., 2016, https://github.com/cmu-delphi/delphi-epidata, 2017-01-11</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00232/10.21105.joss.00232.crossref.xml
+++ b/joss.00232/10.21105.joss.00232.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b5c8730ae352ba8b8860085a0fff4982</doi_batch_id>
-    <timestamp>20171023215811</timestamp>
+    <doi_batch_id>d70544cd07ab5e8925aa813b12b13942</doi_batch_id>
+    <timestamp>20171024135109</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>232</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.583325</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/232</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00232</item_number>
+          <identifier id_type="doi">10.21105/joss.00232</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.583325</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/232</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00232</doi>
-          <timestamp>20171023215811</timestamp>
+          <timestamp>20171024135109</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00232</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00232/10.21105.joss.00232.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>FastQC A Quality Control Tool for High Throughput Sequence Data, http://www.bioinformatics.babraham.ac.uk/projects/fastqc/, Andrews, S, 2013-10-22, 2012, Hons</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Sickle: A Sliding-Window, Adaptive, Quality-Based Trimming Tool for FastQ Files, https://github.com/najoshi/sickle., 1.33, Joshi, N A and Fass, J N, 2011</unstructured_citation></citation><citation key="ref3"><doi>10.1186/1756-0500-5-337</doi></citation><citation key="ref4"><doi>10.1186/1471-2105-9-11</doi></citation></citation_list>
       </journal_article>

--- a/joss.00234/10.21105.joss.00234.crossref.xml
+++ b/joss.00234/10.21105.joss.00234.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a5cb709e8a8467cef02859fd6224f4e7</doi_batch_id>
-    <timestamp>20171023215820</timestamp>
+    <doi_batch_id>f46b2e293ce7330f2f0f00bd2b7d1427</doi_batch_id>
+    <timestamp>20171024135111</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>234</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.582354</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/234</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00234</item_number>
+          <identifier id_type="doi">10.21105/joss.00234</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.582354</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/234</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00234</doi>
-          <timestamp>20171023215820</timestamp>
+          <timestamp>20171024135111</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00234</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00234/10.21105.joss.00234.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>for Biotechnology Information (US), National Center, Basic Local Alignment Search Tool, https://blast.ncbi.nlm.nih.gov/Blast.cgi, 2017-03-03</unstructured_citation></citation><citation key="ref2"><unstructured_citation>for Biotechnology Information (US), National Center, Entrez Programming Utilities Help, 2005, https://www.ncbi.nlm.nih.gov/books/NBK3836/, 2017-03-03</unstructured_citation></citation><citation key="ref3"><unstructured_citation>for Biotechnology Information (US), National Center, Common URL API, http://www.ncbi.nlm.nih.gov/BLAST/Doc/urlapi.html, 2017-03-03</unstructured_citation></citation><citation key="ref4"><unstructured_citation>for Biotechnology Information (US), National Center, Entrez Programming Utilities Help, 2010, https://www.ncbi.nlm.nih.gov/books/NBK25501/, 2017-03-03</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Fields C., Bio-EUtilities, https://github.com/bioperl/Bio-EUtilities, 2017-03-03</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Fields C., Bio-EUtilities, https://github.com/bioperl/bioperl-run, 2017-03-03</unstructured_citation></citation><citation key="ref7"><doi>10.1101/gr.361602</doi></citation><citation key="ref8"><doi>10.1093/bioinformatics/btp163</doi></citation></citation_list>
       </journal_article>

--- a/joss.00235/10.21105.joss.00235.crossref.xml
+++ b/joss.00235/10.21105.joss.00235.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>0c064de4b1f51ff724353da8795ac812</doi_batch_id>
-    <timestamp>20171023215829</timestamp>
+    <doi_batch_id>dbba897d30ab11573e2bf4eff7abfa3d</doi_batch_id>
+    <timestamp>20171024135112</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>235</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.821196</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/235</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00235</item_number>
+          <identifier id_type="doi">10.21105/joss.00235</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.821196</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/235</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00235</doi>
-          <timestamp>20171023215829</timestamp>
+          <timestamp>20171024135112</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00235</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00235/10.21105.joss.00235.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Tange, Ole and others, 2015-06-09 05:05:54 +0000, 2015-06-09 05:05:54 +0000, The USENIX Magazine, 1, 42–47, Gnu parallel-the command-line power tool, 36, 2011</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Dantas, WG and de Oliveira, MJ and Stilck, JF, 2015-06-09 04:54:35 +0000, 2015-06-09 04:54:35 +0000, Journal of Statistical Mechanics: Theory and Experiment, 08, P08009, IOP Publishing, Revisiting the one-dimensional diffusive contact process, 2007, 2007</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Epshtein, Boris and Ofek, Eyal and Wexler, Yonatan, Computer Vision and Pattern Recognition (CVPR), 2010 IEEE Conference on, 2015-06-09 04:24:18 +0000, 2015-06-09 04:24:18 +0000, IEEE, 2963–2970, Detecting text in natural scenes with stroke width transform, 2010</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Chen, Huizhong and Tsai, Sam S and Schroth, Georg and Chen, David M and Grzeszczuk, Radek and Girod, Bernd, Image Processing (ICIP), 2011 18th IEEE International Conference on, 2015-06-09 04:18:38 +0000, 2015-06-09 04:18:38 +0000, IEEE, 2609–2612, Robust text detection in natural images with edge-enhanced maximally stable extremal regions, 2011</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Azuma, Takehiro, 2015-06-09 03:47:46 +0000, 2015-06-09 03:47:46 +0000, arXiv preprint hep-th/0401120, Matrix models and the gravitational interaction, 2004</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Schulz, Hannes and Behnke, Sven, Proceedings of the DAGM Workshop on New Challenges in Neural Computation, 2015-06-08 18:02:05 +0000, 2015-06-08 18:02:05 +0000, 58–61, Object-class segmentation using deep convolutional neural networks, 2011</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Szegedy, Christian and Toshev, Alexander and Erhan, Dumitru, Advances in Neural Information Processing Systems, 2015-06-08 17:56:26 +0000, 2015-06-08 17:56:26 +0000, 2553–2561, Deep neural networks for object detection, 2013</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Goodfellow, Ian J and Bulatov, Yaroslav and Ibarz, Julian and Arnoud, Sacha and Shet, Vinay, 2015-06-08 17:51:08 +0000, 2015-06-08 17:51:08 +0000, arXiv preprint arXiv:1312.6082, Multi-digit number recognition from street view imagery using deep convolutional neural networks, 2013</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Lindeberg, Tony, 2015-06-07 21:09:10 +0000, 2015-06-07 21:09:10 +0000, Scholarpedia, 5, 10491, Scale invariant feature transform, 7, 2012</unstructured_citation></citation><citation key="ref10"><unstructured_citation>Le Cun, B Boser and Denker, John S and Henderson, D and Howard, Richard E and Hubbard, W and Jackel, Lawrence D, Advances in neural information processing systems, 2015-06-07 21:01:56 +0000, 2015-06-07 21:01:56 +0000, Citeseer, Handwritten digit recognition with a back-propagation network, 1990</unstructured_citation></citation><citation key="ref11"><unstructured_citation>Savva, Manolis and Kong, Nicholas and Chhajta, Arti and Fei-Fei, Li and Agrawala, Maneesh and Heer, Jeffrey, Proceedings of the 24th annual ACM symposium on User interface software and technology, 2015-06-07 20:02:58 +0000, 2015-06-07 20:02:58 +0000, ACM, 393–402, Revision: Automated classification, analysis and redesign of chart images, 2011</unstructured_citation></citation><citation key="ref12"><unstructured_citation>Clark, Christopher and Divvala, Santosh, 2015-06-07 20:02:19 +0000, 2015-06-07 20:02:19 +0000, Looking Beyond Text: Extracting Figures, Tables and Captions from Computer Science Papers</unstructured_citation></citation><citation key="ref13"><unstructured_citation>Smith, Ray, ICDAR, 2015-06-07 20:01:04 +0000, 2015-06-07 20:01:04 +0000, 1, 629–633, An Overview of the Tesseract OCR Engine., 7, 2007</unstructured_citation></citation><citation key="ref14"><unstructured_citation>Redmon, Joseph, Darknet: Open Source Neural Networks in C, \urlhttp://pjreddie.com/darknet/, 2013–2016</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00236/10.21105.joss.00236.crossref.xml
+++ b/joss.00236/10.21105.joss.00236.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ccc2b4bb52b5e9772b9c82aef8eef35d</doi_batch_id>
-    <timestamp>20171023215838</timestamp>
+    <doi_batch_id>6f78da1057031018ad2b9a74deb45b88</doi_batch_id>
+    <timestamp>20171024135113</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>236</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.556145</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/236</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00236</item_number>
+          <identifier id_type="doi">10.21105/joss.00236</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.556145</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/236</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00236</doi>
-          <timestamp>20171023215838</timestamp>
+          <timestamp>20171024135113</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00236</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00236/10.21105.joss.00236.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Mutel, Christopher, brightway2-data, 2016, https://brightwaylca.org/, 2017-04-05</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Mutel, Christopher, brightway documentation, 2015, https://docs.brightwaylca.org/, 2017-04-05</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Mutel, Christopher, brightway2 development blog, 2014, https://chris.mutel.org/, 2017-04-05</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Mutel, Christopher, brightway2-data, 2012, https://bitbucket.org/cmutel/brightway2-data, 2017-04-05</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Mutel, Christopher, brightway2-calc, 2012, https://bitbucket.org/cmutel/brightway2-calc, 2017-04-05</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Mutel, Christopher, brightway2, 2012, https://bitbucket.org/cmutel/brightway2, 2017-04-05</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Mutel, Christopher, brightway2-io, 2015, https://bitbucket.org/cmutel/brightway2-io, 2017-04-05</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Mutel, Christopher, stats-arrays, 2013, https://bitbucket.org/cmutel/stats_arrays, 2017-04-05</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Mutel, Christopher, brightway2-analyzer, 2015, https://bitbucket.org/cmutel/brightway2-parameters, 2017-04-05</unstructured_citation></citation><citation key="ref10"><doi>10.1111/j.1530-9290.2010.00294.x</doi></citation><citation key="ref11"><doi>10.1021/es3050949</doi></citation><citation key="ref12"><doi>10.1021/es203117z</doi></citation></citation_list>
       </journal_article>

--- a/joss.00242/10.21105.joss.00242.crossref.xml
+++ b/joss.00242/10.21105.joss.00242.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>1065dc519a07fe9203cfe259c136e2c9</doi_batch_id>
-    <timestamp>20171023215847</timestamp>
+    <doi_batch_id>f69248b82e47b1687c7145a766bad2a9</doi_batch_id>
+    <timestamp>20171024135114</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>242</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.803483</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/242</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00242</item_number>
+          <identifier id_type="doi">10.21105/joss.00242</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.803483</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/242</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00242</doi>
-          <timestamp>20171023215847</timestamp>
+          <timestamp>20171024135114</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00242</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00242/10.21105.joss.00242.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Anderson, S. M. and Mendoza, B. S., SHGYield, 2017, GitHub Repository, https://github.com/roguephysicist/SHGYield</unstructured_citation></citation><citation key="ref2"><doi>10.3389/fmats.2017.00012</doi></citation><citation key="ref3"><doi>10.1103/PhysRevB.94.115314</doi></citation><citation key="ref4"><doi>10.13140/RG.2.2.35619.66082</doi></citation><citation key="ref5"><unstructured_citation>Anderson, S. M. and Mendoza, B. S., Derivation of the three-layer model for surface second-harmonic generation, 2016-04-27, arXiv:1604.07722</unstructured_citation></citation><citation key="ref6"><doi>10.1103/PhysRevB.93.235304</doi></citation><citation key="ref7"><doi>10.1103/PhysRevB.91.075302</doi></citation></citation_list>
       </journal_article>

--- a/joss.00243/10.21105.joss.00243.crossref.xml
+++ b/joss.00243/10.21105.joss.00243.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c8a265430a51b1113afd12aee982db17</doi_batch_id>
-    <timestamp>20171023215855</timestamp>
+    <doi_batch_id>533f94a37868104343d900cd6f549cb0</doi_batch_id>
+    <timestamp>20171024135115</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>243</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.4964378.v1</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/243</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00243</item_number>
+          <identifier id_type="doi">10.21105/joss.00243</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.4964378.v1</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/243</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00243</doi>
-          <timestamp>20171023215855</timestamp>
+          <timestamp>20171024135115</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00243</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00243/10.21105.joss.00243.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1186/s13059-016-0997-x</doi></citation><citation key="ref2"><doi>10.1186/gb-2014-15-3-r46</doi></citation><citation key="ref3"><unstructured_citation>Kokot, M. and Długosz, M. and Deorowicz, S., KMC 3: counting and manipulating k-mer statistics, ArXiv e-prints, 1701.08022, 2017, jan, http://adsabs.harvard.edu/abs/2017arXiv170108022K, 1</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Starting with correlation coefficients (based on numerous characters) among species of a systematic unit, the authors developed a method for grouping species, and regrouping the resultant assemblages, to form a classifactory hierarchy most easily expressed as a treelike diagram of relationships. The details of this method are described, using as an example a group of bees. The resulting classification was similar to that previously established by classical systematic methods, although some taxonomic changes were made in view of the new light thrown on relationships. The method is time consuming, although practical in isolated cases, with punched-card machines such as were used; it becomes generally practical with increasingly widely available digital computers., Sokal, Robert R. and Michener, Charles D., 0001948000237, 0022-8850, The University of Kansas Science Bulletin, 1409–1438, A Statistical Method for Evaluating Systematic Relationships, http://ci.nii.ac.jp/naid/10011579647/en/, 38, 1958</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Boratyn, Greg and Camacho, Christiam and Federhen, Scott and Merezhuk, Yuri and Madden, Tom and Schoch, Conrad and Zaretskaya, Irena, MOLE-BLAST a new tool to search and classify multiple sequences, \urlftp://ftp.ncbi.nlm.nih.gov/blast/documents/moleblast_poster2014.pdf, 2014</unstructured_citation></citation><citation key="ref6"><doi>10.1093/bioinformatics/btu033</doi></citation></citation_list>
       </journal_article>

--- a/joss.00244/10.21105.joss.00244.crossref.xml
+++ b/joss.00244/10.21105.joss.00244.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7979dbc94e58859437d70b084d92e3f3</doi_batch_id>
-    <timestamp>20171023215904</timestamp>
+    <doi_batch_id>f19c61660cc530bffc8b0d5af0e9eb3e</doi_batch_id>
+    <timestamp>20171024135116</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>244</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.571547</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/244</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00244</item_number>
+          <identifier id_type="doi">10.21105/joss.00244</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.571547</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/244</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00244</doi>
-          <timestamp>20171023215904</timestamp>
+          <timestamp>20171024135116</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00244</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00244/10.21105.joss.00244.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Mutel, Christopher, brightway2-regional, 2014, https://bitbucket.org/cmutel/brightway2-regional, 2017-04-14</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Mutel, Christopher, brightway2, 2012, https://brightwaylca.org/, 2017-04-05</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Mutel, Christopher, constructive geometries, 2015, https://bitbucket.org/cmutel/py-constructive-geometries, 2017-04-14</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Mutel, Christopher, pandarus-remote, 2016, https://github.com/cmutel/pandarus_remote, 2017-04-14</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00247/10.21105.joss.00247.crossref.xml
+++ b/joss.00247/10.21105.joss.00247.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>003bd5c9ca82c7fc3e5fe8442aea785d</doi_batch_id>
-    <timestamp>20171023215912</timestamp>
+    <doi_batch_id>d590cbb49da34899b009d56b3712de32</doi_batch_id>
+    <timestamp>20171024135117</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>247</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.582402</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/247</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00247</item_number>
+          <identifier id_type="doi">10.21105/joss.00247</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.582402</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/247</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00247</doi>
-          <timestamp>20171023215912</timestamp>
+          <timestamp>20171024135117</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00247</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00247/10.21105.joss.00247.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Morgan, B. J., In Preparation</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Van der Ven, Anton and Bhattacharya, Jishnu and Belak, Anna A., 2016-10-07 10:36:53 +0000, 2016-10-07 10:36:53 +0000, Acc. Chem. Res., may, 5, 1216–1225, Understanding Li Diffusion in Li-Intercalation Compounds, 46, 2013, 5</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Murch, G. E., 2016-03-09 11:47:27 +0000, 2016-03-09 11:47:27 +0000, Sol. Stat. Ionics, 3, 177–198, The Haven ratio in fast ionic conductors, 7, 1982</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Kutner, R., 2016-08-05 12:46:59 +0000, 2016-08-05 12:46:59 +0000, Phys. Lett., 4, 239–240, Chemical Diffusion in the Lattice Gas of Non-Interacting Particles, 81A, 1981</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Morgan, Benjamin J. and Madden, P. A., 2012-12-20 17:59:22 +0000, 2013-07-24 19:34:17 +0000, J. Phys-Condens. Matter, jun, 27, 275303, Absence of a space-charge-derived enhancement of ionic conductivity in β|γ-heterostructured 7H- and 9R-AgI, 24, 2012, 6</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Murch, G. E. and Thorn, R. J., 2017-04-14 12:42:04 +0000, 2017-04-14 12:42:04 +0000, Philosophical Magazine, 3, 529–539, Computer simulation of ionic conductivity Application to β\textacutedbl-alumina, 36, 1977</unstructured_citation></citation><citation key="ref7"><doi>10.1007/978-1-4020-5295-8_1</doi></citation><citation key="ref8"><unstructured_citation>Catlow, C. Richard A., 2012-12-20 17:14:00 +0000, 2012-12-20 17:14:37 +0000, Sol. Stat. Ionics, 89–107, Static Lattice Simulation of Structure and Transport in Superionic Conductors, 8, 1983</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Howard, R. E. and Lidiard, A. B., 2013-06-17 10:49:20 +0000, 2013-06-17 10:49:20 +0000, Rep Prog Phys., 161–240, Matter Transport in Solids, 27, 1964</unstructured_citation></citation><citation key="ref10"><doi>10.1142/9789814503228_0003</doi></citation></citation_list>
       </journal_article>

--- a/joss.00248/10.21105.joss.00248.crossref.xml
+++ b/joss.00248/10.21105.joss.00248.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>eb98d25b8fba512db9350ca117dfdafc</doi_batch_id>
-    <timestamp>20171023215921</timestamp>
+    <doi_batch_id>20ef9c53be997d9c58ce9856f5a4ead8</doi_batch_id>
+    <timestamp>20171024135119</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>248</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.569492</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/248</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00248</item_number>
+          <identifier id_type="doi">10.21105/joss.00248</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.569492</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/248</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00248</doi>
-          <timestamp>20171023215921</timestamp>
+          <timestamp>20171024135119</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00248</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00248/10.21105.joss.00248.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5194/gmd-8-939-2015</doi></citation><citation key="ref2"><doi>10.5194/bg-13-4329-2016</doi></citation><citation key="ref3"><doi>10.3233/978-1-61499-649-1-87</doi></citation><citation key="ref4"><doi>10.1109/MCSE.2007.53</doi></citation><citation key="ref5"><unstructured_citation>Data Structures for Statistical Computing in Python, McKinney, Wes, Proceedings of the 9th Python in Science Conference, 51 - 56, 2010, van der Walt, Stéfan and Millman, Jarrod</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00250/10.21105.joss.00250.crossref.xml
+++ b/joss.00250/10.21105.joss.00250.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c7aa1017026776ff69d9a04228e476ce</doi_batch_id>
-    <timestamp>20171023215931</timestamp>
+    <doi_batch_id>fcd0736a4af1929427a561cdc9300533</doi_batch_id>
+    <timestamp>20171024135120</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>250</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.580775</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/250</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00250</item_number>
+          <identifier id_type="doi">10.21105/joss.00250</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.580775</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/250</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00250</doi>
-          <timestamp>20171023215931</timestamp>
+          <timestamp>20171024135120</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00250</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00250/10.21105.joss.00250.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Met Office, Cartopy: a cartographic python library with a matplotlib interface, 2010 - 2015, Exeter, Devon , http://scitools.org.uk/cartopy</unstructured_citation></citation><citation key="ref2"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref3"><doi>10.1029/2012GL052219</doi></citation></citation_list>
       </journal_article>

--- a/joss.00255/10.21105.joss.00255.crossref.xml
+++ b/joss.00255/10.21105.joss.00255.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>bcb56f2175fbf958c8f7a9612028eef7</doi_batch_id>
-    <timestamp>20171023215939</timestamp>
+    <doi_batch_id>08bb62a9dc779bf6c6f92280b394e153</doi_batch_id>
+    <timestamp>20171024135121</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>255</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.808540</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/255</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00255</item_number>
+          <identifier id_type="doi">10.21105/joss.00255</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.808540</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/255</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00255</doi>
-          <timestamp>20171023215939</timestamp>
+          <timestamp>20171024135121</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00255</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00255/10.21105.joss.00255.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Didion, John P, xphyle: extraordinarily simple file handling, 2017, https://github.com/jdidion/xphyle, 2017-04-29</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00256/10.21105.joss.00256.crossref.xml
+++ b/joss.00256/10.21105.joss.00256.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>da8c5d474be56a5a8035d0fa8d89b9ea</doi_batch_id>
-    <timestamp>20171023215948</timestamp>
+    <doi_batch_id>4fa769e8f7d42216158f1d2952a58332</doi_batch_id>
+    <timestamp>20171024135122</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>256</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.574887</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/256</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00256</item_number>
+          <identifier id_type="doi">10.21105/joss.00256</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.574887</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/256</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00256</doi>
-          <timestamp>20171023215948</timestamp>
+          <timestamp>20171024135122</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00256</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00256/10.21105.joss.00256.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Studying artificial life with cellular automata, Langton, Christopher G, Physica D: Nonlinear Phenomena, 22, 1-3, 120–149, 1986, Elsevier</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Artificial life: the quest for a new creation, Levy, Steven, 1992, Pantheon, New York</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Langton’s Ants - in Javascript, Scrivener, Ross, 2012, http://rossscrivener.co.uk/blog/langtons-ants-in-javascript</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00257/10.21105.joss.00257.crossref.xml
+++ b/joss.00257/10.21105.joss.00257.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>98aba3224878759e41ec5a39ced04a32</doi_batch_id>
-    <timestamp>20171023215957</timestamp>
+    <doi_batch_id>f24ebccf4bfa84c83a9041787838ba83</doi_batch_id>
+    <timestamp>20171024135123</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>257</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.846925</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/257</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00257</item_number>
+          <identifier id_type="doi">10.21105/joss.00257</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.846925</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/257</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00257</doi>
-          <timestamp>20171023215957</timestamp>
+          <timestamp>20171024135123</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00257</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00257/10.21105.joss.00257.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Anscombe, Francis J, The transformation of Poisson, binomial and negative-binomial data, Biometrika, 35, 3/4, 246-254, 0006-3444, 1948</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00258/10.21105.joss.00258.crossref.xml
+++ b/joss.00258/10.21105.joss.00258.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>2b25ba88dc0e7a894f911458342152a2</doi_batch_id>
-    <timestamp>20171023220005</timestamp>
+    <doi_batch_id>b821cd33d5f77490a67829f66ecfe2ce</doi_batch_id>
+    <timestamp>20171024135124</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>258</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.580120</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/258</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00258</item_number>
+          <identifier id_type="doi">10.21105/joss.00258</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.580120</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/258</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00258</doi>
-          <timestamp>20171023220005</timestamp>
+          <timestamp>20171024135124</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00258</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00258/10.21105.joss.00258.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Mayer, Andreas and Mora, Thierry and Rivoire, Olivier and Walczak, Aleksandra M, Diversity of immune strategies explained by adaptation to pathogen statistics, Proceedings of the National Academy of Sciences, 31, 8630–8635, 113, 2016</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Jones, Eric and Oliphant, Travis and Peterson, Pearu and others, SciPy: Open source scientific tools for Python, 2001–, http://www.scipy.org/, [Online; accessed 2017/03/30]</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Spall, James C, Implementation of the Simulteaneous Perturbation Algorithm for Stochastic Optimization, IEEE Transactions on Aerospace and Electronic Systems, 1998, 3, 34, 817 – 823</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00260/10.21105.joss.00260.crossref.xml
+++ b/joss.00260/10.21105.joss.00260.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>275f91f0e6619272496a2cf65f8b0316</doi_batch_id>
-    <timestamp>20171023220013</timestamp>
+    <doi_batch_id>ad718290a994100ac3d32199ac85af9a</doi_batch_id>
+    <timestamp>20171024135125</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>260</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.801452</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/260</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00260</item_number>
+          <identifier id_type="doi">10.21105/joss.00260</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.801452</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/260</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00260</doi>
-          <timestamp>20171023220013</timestamp>
+          <timestamp>20171024135125</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00260</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00260/10.21105.joss.00260.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2017, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>RStudio: Integrated Development Environment for R, RStudio Team, RStudio, Inc., Boston, MA, 2016, http://www.rstudio.com/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>readr: Read Rectangular Text Data, Wickham, Hadley and Hester, Jim and Francois, Romain, 2017, R package version 1.1.0, https://CRAN.R-project.org/package=readr</unstructured_citation></citation><citation key="ref4"><unstructured_citation>tibble: Simple Data Frames, Wickham, Hadley and Francois, Romain and Müller, Kirill, 2017, R package version 1.3.0, https://CRAN.R-project.org/package=tibble</unstructured_citation></citation><citation key="ref5"><doi>10.18637/jss.v040.i08</doi></citation><citation key="ref6"><unstructured_citation>magrittr: A Forward-Pipe Operator for R, Bache, Stefan Milton and Wickham, Hadley, 2014, R package version 1.5, https://CRAN.R-project.org/package=magrittr</unstructured_citation></citation><citation key="ref7"><unstructured_citation>ore: An R Interface to the Oniguruma Regular Expression Library, Clayden, Jon and based on Onigmo by K. Kosako and Takata, K., 2016, R package version 1.5.0, https://CRAN.R-project.org/package=ore</unstructured_citation></citation><citation key="ref8"><unstructured_citation>dplyr: A Grammar of Data Manipulation, Wickham, Hadley and Francois, Romain, 2016, R package version 0.5.0, https://CRAN.R-project.org/package=dplyr</unstructured_citation></citation><citation key="ref9"><unstructured_citation>matrixStats: Functions that Apply to Rows and Columns of Matrices (and to Vectors), Bengtsson, Henrik, 2017, R package version 0.52.1, https://CRAN.R-project.org/package=matrixStats</unstructured_citation></citation><citation key="ref10"><unstructured_citation>stringr: Simple, Consistent Wrappers for Common String Operations, Wickham, Hadley, 2017, R package version 1.2.0, https://CRAN.R-project.org/package=stringr</unstructured_citation></citation><citation key="ref11"><unstructured_citation>R package stringi: Character string processing facilities, Gagolewski, Marek and Tartanus, Bartek, 2016, http://www.gagolewski.com/software/stringi/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00265/10.21105.joss.00265.crossref.xml
+++ b/joss.00265/10.21105.joss.00265.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b74a70d7d5694defcf71c092bc242ddf</doi_batch_id>
-    <timestamp>20171023220022</timestamp>
+    <doi_batch_id>6d6f9543e7763b4f96c8cba283e04909</doi_batch_id>
+    <timestamp>20171024135126</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>265</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.582351</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/265</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00265</item_number>
+          <identifier id_type="doi">10.21105/joss.00265</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.582351</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/265</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00265</doi>
-          <timestamp>20171023220022</timestamp>
+          <timestamp>20171024135126</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00265</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00265/10.21105.joss.00265.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/REV.2014.6784247</doi></citation><citation key="ref2"><doi>10.1109/ConTEL.2015.7231225</doi></citation><citation key="ref3"><doi>10.1109/ISSNIP.2014.6827678</doi></citation><citation key="ref4"><doi>10.1109/PlatCon.2017.7883724</doi></citation><citation key="ref5"><doi>10.1109/SIoT.2014.8</doi></citation><citation key="ref6"><doi>10.3390/su9040585</doi></citation></citation_list>
       </journal_article>

--- a/joss.00267/10.21105.joss.00267.crossref.xml
+++ b/joss.00267/10.21105.joss.00267.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>8f7bb9c1cac258d884b716d971a9b919</doi_batch_id>
-    <timestamp>20171023220035</timestamp>
+    <doi_batch_id>9dfedeb964d3a9579f7f6a600ea5a389</doi_batch_id>
+    <timestamp>20171024135127</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>267</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.838308</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/267</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00267</item_number>
+          <identifier id_type="doi">10.21105/joss.00267</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.838308</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/267</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00267</doi>
-          <timestamp>20171023220035</timestamp>
+          <timestamp>20171024135127</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00267</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00267/10.21105.joss.00267.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/0167-8396(87)90012-4</doi></citation><citation key="ref2"><doi>10.1016/0010-4485(89)90015-8</doi></citation><citation key="ref3"><doi>10.1016/0010-4485(90)90039-f</doi></citation><citation key="ref4"><doi>10.1016/0167-8396(91)90047-f</doi></citation><citation key="ref5"><doi>10.2307/2008438</doi></citation><citation key="ref6"><doi>10.1090/s0025-5718-96-00759-4</doi></citation><citation key="ref7"><doi>10.1016/s0010-4485(98)00052-9</doi></citation><citation key="ref8"><doi>10.1016/s0010-4485(86)80013-6</doi></citation><citation key="ref9"><doi>10.1016/j.cagd.2012.03.001</doi></citation><citation key="ref10"><unstructured_citation>00255718, 10886842, https://www.jstor.org/stable/4100244, Jónsson, GuđbjörnF. and Vavasis, Stephen A., Mathematics of Computation, 249, 221-262, American Mathematical Society, Accurate Solution of Polynomial Equations Using Macaulay Resultant Matrices, 74, 2005</unstructured_citation></citation><citation key="ref11"><unstructured_citation>Manocha, Dinesh and Demmel, James W., Algorithms for Intersecting Parametric and Algebraic Curves, EECS Department, University of California, Berkeley, 1992, aug, https://www2.eecs.berkeley.edu/Pubs/TechRpts/1992/6266.html, UCB/CSD-92-698, 8</unstructured_citation></citation><citation key="ref12"><unstructured_citation>Farin, Gerald, Curves and Surfaces for CAGD, Fifth Edition: A Practical Guide (The Morgan Kaufmann Series in Computer Graphics), Morgan Kaufmann, 2001, 1558607374, https://www.amazon.com/Curves-Surfaces-CAGD-Fifth-Practical/dp/1558607374</unstructured_citation></citation><citation key="ref13"><unstructured_citation>http://tom.cs.byu.edu/ 557/text/cagd.pdf, Sederberg, Thomas W, Department of Computer Science, Brigham Young University, Lecture notes: Computer Aided Geometric Design, 2016, sep, 9</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00272/10.21105.joss.00272.crossref.xml
+++ b/joss.00272/10.21105.joss.00272.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e68d493a4d6eaa7ff82bd03fd4310afd</doi_batch_id>
-    <timestamp>20171023220044</timestamp>
+    <doi_batch_id>b821077785a394cd887c3f7b5b2adf28</doi_batch_id>
+    <timestamp>20171024135129</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>272</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.822478</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/272</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00272</item_number>
+          <identifier id_type="doi">10.21105/joss.00272</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.822478</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/272</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00272</doi>
-          <timestamp>20171023220044</timestamp>
+          <timestamp>20171024135129</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00272</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00272/10.21105.joss.00272.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Brown, C. Titus and Howe, Adina and Zhang, Qingpeng and Pyrkosz, Alexis B. and Brom, Timothy H., A Reference-Free Algorithm for Computational Normalization of Shotgun Sequencing Data, 2012, arXiv:1203.4802</unstructured_citation></citation><citation key="ref2"><doi>10.12688/f1000research.6924.1</doi></citation><citation key="ref3"><doi>10.1073/pnas.1121464109</doi></citation><citation key="ref4"><doi>10.7287/peerj.preprints.890v1</doi></citation><citation key="ref5"><doi>10.1371/journal.pone.0101271</doi></citation></citation_list>
       </journal_article>

--- a/joss.00279/10.21105.joss.00279.crossref.xml
+++ b/joss.00279/10.21105.joss.00279.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>018d34add525d7dbf0e6b1f5eb3c2140</doi_batch_id>
-    <timestamp>20171023220053</timestamp>
+    <doi_batch_id>39d767a47e0a61b9ed268f80619ea15d</doi_batch_id>
+    <timestamp>20171024135130</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>279</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.804030</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/279</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00279</item_number>
+          <identifier id_type="doi">10.21105/joss.00279</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.804030</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/279</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00279</doi>
-          <timestamp>20171023220053</timestamp>
+          <timestamp>20171024135130</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00279</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00279/10.21105.joss.00279.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>McKinney, Wes and Others, Proceedings of the 9th Python in Science Conference, Scientific Computing, van der Voort S, Millman J, 51–56, Data structures for statistical computing in python, 445, 2010</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Berman, Helen and Henrick, Kim and Nakamura, Haruki, Nature Structural & Molecular Biology, Papers/ScreenLamp Paper/software, 12, 980, Nature Publishing Group, Announcing the worldwide protein data bank, 10, 2003</unstructured_citation></citation><citation key="ref3"><doi>10.1093/nar/28.1.235</doi></citation><citation key="ref4"><unstructured_citation>Tripos Mol2 File Format, Tripos, L, St. Louis, MO: Tripos, 2007</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00280/10.21105.joss.00280.crossref.xml
+++ b/joss.00280/10.21105.joss.00280.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>1dada6a829e2e4b3458cab85fab469df</doi_batch_id>
-    <timestamp>20171023220101</timestamp>
+    <doi_batch_id>bcff1b2087f47d4668605fec1a75d77f</doi_batch_id>
+    <timestamp>20171024135131</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>280</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.852471</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/280</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00280</item_number>
+          <identifier id_type="doi">10.21105/joss.00280</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.852471</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/280</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00280</doi>
-          <timestamp>20171023220101</timestamp>
+          <timestamp>20171024135131</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00280</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00280/10.21105.joss.00280.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.6084/m9.figshare.5018774.v1</doi></citation><citation key="ref2"><unstructured_citation>Balay, Satish and Abhyankar, Shrirang and Adams, Mark F. and Brown, Jed and Brune, Peter and Buschelman, Kris and Dalcin, Lisandro and Eijkhout, Victor and Gropp, William D. and Kaushik, Dinesh and Knepley, Matthew G. and McInnes, Lois Curfman and Rupp, Karl and Smith, Barry F. and Zampini, Stefano and Zhang, Hong and Zhang, Hong, PETSc Users Manual, Argonne National Laboratory, 2016, ANL-95/11 - Revision 3.7, http://www.mcs.anl.gov/petsc</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00281/10.21105.joss.00281.crossref.xml
+++ b/joss.00281/10.21105.joss.00281.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>fb1a4362d6e973646c22abae085bf98d</doi_batch_id>
-    <timestamp>20171023220110</timestamp>
+    <doi_batch_id>46795a48afa8b65b88632d6f5380357b</doi_batch_id>
+    <timestamp>20171024135132</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>281</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.835206</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/281</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00281</item_number>
+          <identifier id_type="doi">10.21105/joss.00281</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.835206</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/281</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00281</doi>
-          <timestamp>20171023220110</timestamp>
+          <timestamp>20171024135132</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00281</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00281/10.21105.joss.00281.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>OpenSpace, openspaceproject.com, 2017, http://openspaceproject.com, 2017-06-01</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Bock, Alexander and Axelsson, Emil and Bladin, Kalle and Costa, Jonathas and Payne, Gene and Territo, Matthew and Kilby, Joakim and Myers, Eric and Kuznetsova, Masha and Emmart, Carter and Ynnerman, Anders, OpenSpace: An open-source astrovisualization framework, 2017, https://github.com/OpenSpace/OpenSpace, 2017-06-01</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Axelsson, Emil and Costa, Jonathas and Silva, Cláudio T. and Emmart, Carter and Bock, Alexander and Ynnerman, Anders, Computer Graphics Forum, Proceedings of EuroVis, 2016-12-18 20:08:53 +0000, 2016-12-18 20:15:29 +0000, Dynamic Scene Graph: Enabling Scaling, Positioning, and Navigation in the Universe, 2017</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Bladin, Karl and Axelsson, Emil and Broberg, Erik and Emmart, Carter and Ljung, Patric and Bock, Alexander and Ynnerman, Anders, IEEE Transactions on Visualization and Computer Graphics, Globe Browsing: Contextualized Spatio-Temporal Planetary Surface Visualization, 2017</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Bock, Alexander and Pembroke, Asher and Mays, M. Leila and Ynnerman, Anders, 2016-10-01 11:18:45 +0000, 2016-10-01 11:18:49 +0000, Poster Presentation at American Geophysical Union, Fall Meeting, OpenSpace: An Open-Source Framework for Data Visualization and Contextualization, 2015</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Bock, Alexander and Marcinkowski, Michal and Kilby, Joakim and Emmart, Carter and Ynnerman, Anders, 2016-10-01 11:18:22 +0000, 2016-10-01 11:18:26 +0000, Poster at IEEE Vis, OpenSpace: Public Dissemination of Space Mission Profiles, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00282/10.21105.joss.00282.crossref.xml
+++ b/joss.00282/10.21105.joss.00282.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>dd56cd82f5811f52b88ec24cda6ba646</doi_batch_id>
-    <timestamp>20171023220119</timestamp>
+    <doi_batch_id>663e4e34e7ddc2a30cc9abc05fb0f6ad</doi_batch_id>
+    <timestamp>20171024135133</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>282</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.826723</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/282</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00282</item_number>
+          <identifier id_type="doi">10.21105/joss.00282</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.826723</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/282</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00282</doi>
-          <timestamp>20171023220119</timestamp>
+          <timestamp>20171024135133</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00282</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00282/10.21105.joss.00282.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1093/bioinformatics/btp352</doi></citation><citation key="ref2"><unstructured_citation>arXiv, 1605.09070, Břinda, Karel and Boeva, Valentina and Kucherov, Gregory, 1605.09070, 1-21, Dynamic read mapping and online consensus calling for better variant detection, http://arxiv.org/abs/1605.09070, 2016</unstructured_citation></citation><citation key="ref3"><doi>10.1093/bioinformatics/btp324</doi></citation><citation key="ref4"><doi>10.1093/bioinformatics/btu146</doi></citation></citation_list>
       </journal_article>

--- a/joss.00289/10.21105.joss.00289.crossref.xml
+++ b/joss.00289/10.21105.joss.00289.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>cfadf0704cfc712365ba01d324fd055b</doi_batch_id>
-    <timestamp>20171023220128</timestamp>
+    <doi_batch_id>1d78df4a7b81e009fd984fe7449dbe02</doi_batch_id>
+    <timestamp>20171024135134</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>289</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.841337</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/289</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00289</item_number>
+          <identifier id_type="doi">10.21105/joss.00289</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.841337</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/289</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00289</doi>
-          <timestamp>20171023220128</timestamp>
+          <timestamp>20171024135134</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00289</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00289/10.21105.joss.00289.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1007/978-3-319-33742-5_4</doi></citation><citation key="ref2"><doi>10.1145/2616498.2616534</doi></citation><citation key="ref3"><doi>https://doi.org/10.1016/j.bdr.2017.04.001</doi></citation><citation key="ref4"><unstructured_citation>Portable Hardware Locality (hwloc), https://www.open-mpi.org/projects/hwloc/, 2017-06-07</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00291/10.21105.joss.00291.crossref.xml
+++ b/joss.00291/10.21105.joss.00291.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>4737da0798fb6323d14d7972743803a5</doi_batch_id>
-    <timestamp>20171023220137</timestamp>
+    <doi_batch_id>1502b4ed53152fdc876670a0a4bbdcb5</doi_batch_id>
+    <timestamp>20171024135135</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>291</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.825709</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/291</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00291</item_number>
+          <identifier id_type="doi">10.21105/joss.00291</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.825709</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/291</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00291</doi>
-          <timestamp>20171023220137</timestamp>
+          <timestamp>20171024135135</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00291</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00291/10.21105.joss.00291.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Potentials of active and passive geospatial crowdsourcing in complementing Sentinel data and supporting Copernicus service portfolio, , accepted, en, , 2017-03-13, Proceedings of the IEEE, Dell’Acqua, Fabio and De Vecchi, Daniele, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>The Rise of the Citizen Data Scientist, https://www.ngdata.com/the-rise-of-the-citizen-data-scientist/, the data scientist’s function is at the core of organizational success with big data, humanizing organizational data to help businesses better understand their consumers., 2016-11-16, NGDATA, Burgelman, Luc, apr, 2015, 4</unstructured_citation></citation><citation key="ref3"><unstructured_citation>How The Citizen Data Scientist Will Democratize Big Data, http://www.forbes.com/sites/bernardmarr/2016/04/01/how-the-citizen-data-scientist-will-democratize-big-data/, The rise of the citizen data scientist is a subject which is creating a lot of excitement at the moment. Put simply (and a bit bluntly) businesses, particularly larger ones with more mature Big Data analytical operations, are finding that it is too important to be left solely in the [...], 2016-11-16, Forbes, Marr, Bernard</unstructured_citation></citation><citation key="ref4"><doi>10.3390/rs8110905</doi></citation><citation key="ref5"><unstructured_citation>Xamarin, Xamarin, https://www.xamarin.com/, 2017-07-11</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Agency, European Environment, CORINE Land Cover, https://www.eea.europa.eu/publications/COR0-landcover, 2017-07-11</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Agency, European Space, ESA Research and Service Support, http://wiki.services.eoportal.org/tiki-index.php?page=About+RSS, 2017-07-11</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00293/10.21105.joss.00293.crossref.xml
+++ b/joss.00293/10.21105.joss.00293.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>38811edafad16232a82ece9831bfd460</doi_batch_id>
-    <timestamp>20171023220146</timestamp>
+    <doi_batch_id>e2ce285b02423ac44ba2d4b0d90a5aa6</doi_batch_id>
+    <timestamp>20171024135136</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>293</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.817892</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/293</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00293</item_number>
+          <identifier id_type="doi">10.21105/joss.00293</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.817892</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/293</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00293</doi>
-          <timestamp>20171023220146</timestamp>
+          <timestamp>20171024135136</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00293</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00293/10.21105.joss.00293.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3115/1219840.1219885</doi></citation><citation key="ref2"><unstructured_citation>Kelly, S., NLP Compromise: Natural language processing in javascript, 2016, https://github.com/nlpcompromise/compromise</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Srivastava, N., ner: Client for Stanford Named Entity Reconginiton, 2016, https://github.com/niksrc/ner</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Service, UK Data, ukds.tools.textAnonHelper / Home [BitBucket Wiki], https://bitbucket.org/ukda/ukds.tools.textanonhelper/wiki/Home</unstructured_citation></citation><citation key="ref5"><doi>10.1002/acp.2878</doi></citation></citation_list>
       </journal_article>

--- a/joss.00295/10.21105.joss.00295.crossref.xml
+++ b/joss.00295/10.21105.joss.00295.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>856b4684ace524e26ee99e9bbc7dc616</doi_batch_id>
-    <timestamp>20171023220157</timestamp>
+    <doi_batch_id>a3c0802ea9bb0cca6c189fa66cd8847e</doi_batch_id>
+    <timestamp>20171024135137</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>295</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.834849</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/295</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00295</item_number>
+          <identifier id_type="doi">10.21105/joss.00295</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.834849</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/295</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00295</doi>
-          <timestamp>20171023220157</timestamp>
+          <timestamp>20171024135137</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00295</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00295/10.21105.joss.00295.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2017, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Targeted Learning: Causal Inference for Observational and Experimental Data, van der Laan, Mark J and Rose, Sherri, 2011, Springer Science & Business Media</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Limma: Linear Models for Microarray Data, Smyth, Gordon K, Bioinformatics and computational biology solutions using R and Bioconductor, 397–420, 2005, Springer</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Linear Models and Empirical Bayes Methods for Assessing Differential Expression in Microarray Experiments, Smyth, Gordon K, Statistical Applications in Genetics and Molecular Biology, 3, 1, 1–25, 2004</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Orchestrating high-throughput genomic analysis with Bioconductor, Huber, Wolfgang and Carey, Vincent J and Gentleman, Robert and Anders, Simon and Carlson, Marc and Carvalho, Benilton S and Bravo, Hector Corrada and Davis, Sean and Gatto, Laurent and Girke, Thomas and others, Nature methods, 12, 2, 115–121, 2015, Nature Research</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00296/10.21105.joss.00296.crossref.xml
+++ b/joss.00296/10.21105.joss.00296.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>cdc729bc16e15ddfd463fac1727241bb</doi_batch_id>
-    <timestamp>20171023220206</timestamp>
+    <doi_batch_id>b060e25bef37a7452671c900c7653847</doi_batch_id>
+    <timestamp>20171024135139</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>296</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.814996</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/296</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00296</item_number>
+          <identifier id_type="doi">10.21105/joss.00296</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.814996</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/296</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00296</doi>
-          <timestamp>20171023220206</timestamp>
+          <timestamp>20171024135139</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00296</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00296/10.21105.joss.00296.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Keras, Chollet, François and others, 2015, GitHub, \urlhttps://github.com/fchollet/keras</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Delving deep into rectifiers: Surpassing human-level performance on imagenet classification, He, Kaiming and Zhang, Xiangyu and Ren, Shaoqing and Sun, Jian, Proceedings of the IEEE international conference on computer vision, 1026–1034, 2015</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Deep residual learning for image recognition, He, Kaiming and Zhang, Xiangyu and Ren, Shaoqing and Sun, Jian, Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition, 770–778, 2016</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Going deeper with convolutions, Szegedy, Christian and Liu, Wei and Jia, Yangqing and Sermanet, Pierre and Reed, Scott and Anguelov, Dragomir and Erhan, Dumitru and Vanhoucke, Vincent and Rabinovich, Andrew, Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition, 1–9, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00301/10.21105.joss.00301.crossref.xml
+++ b/joss.00301/10.21105.joss.00301.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ac0217c1b06f49c4fda80a27dfed1ce8</doi_batch_id>
-    <timestamp>20171023220214</timestamp>
+    <doi_batch_id>d4fffac3f9021263aea8387fcef4589b</doi_batch_id>
+    <timestamp>20171024135140</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>301</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.832338</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/301</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00301</item_number>
+          <identifier id_type="doi">10.21105/joss.00301</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.832338</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/301</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00301</doi>
-          <timestamp>20171023220214</timestamp>
+          <timestamp>20171024135140</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00301</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00301/10.21105.joss.00301.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/j.jcp.2007.03.005</doi></citation><citation key="ref2"><doi>10.1006/jcph.2000.6484</doi></citation><citation key="ref3"><doi>10.1006/jcph.1993.1162</doi></citation><citation key="ref4"><doi>10.1063/1.4866444</doi></citation><citation key="ref5"><unstructured_citation>Towards the study of flying snake aerodynamics, and an analysis of the direct forcing method, Krishnan, Anush, 2015, Boston University</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00305/10.21105.joss.00305.crossref.xml
+++ b/joss.00305/10.21105.joss.00305.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>581d74301a836ee0a22f3208f94c1e2a</doi_batch_id>
-    <timestamp>20171023220223</timestamp>
+    <doi_batch_id>9bf6ec57519672a2ad551d0fef4f92d9</doi_batch_id>
+    <timestamp>20171024135141</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>305</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.803231</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/305</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00305</item_number>
+          <identifier id_type="doi">10.21105/joss.00305</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.803231</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/305</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00305</doi>
-          <timestamp>20171023220223</timestamp>
+          <timestamp>20171024135141</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00305</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00305/10.21105.joss.00305.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Data Retrieval for Small Spatial Regions in OpenStreetMap, Olbricht, Roland M, OpenStreetMap in GIScience, 101–122, 2015, Springer</unstructured_citation></citation><citation key="ref2"><unstructured_citation>The Impact of Society on Volunteered Geographic Information: The Case of OpenStreetMap, Mashhadi, Afra and Quattrone, Giovanni and Capra, Licia, OpenStreetMap in GIScience, 125–141, 2015, Springer</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Analyzing the contributor activity of a volunteered geographic information project—The case of OpenStreetMap, Neis, Pascal and Zipf, Alexander, ISPRS International Journal of Geo-Information, 1, 2, 146–165, 2012, Molecular Diversity Preservation International</unstructured_citation></citation><citation key="ref4"><unstructured_citation>OpenStreetMap contributors, Planet dump retrieved from http://planet.osm.org , \urlhttp://www.openstreetmap.org, 2017</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Osmar: OpenStreetMap and R, 5, 20734859, OpenStreetMap provides freely accessible and editable geographic data. The osmar package smoothly integrates the OpenStreetMap project into the R ecosystem. The osmar package provides infrastructure to access OpenStreetMap data from different sources, to enable working with the OSM data in the familiar R idiom, and to convert the data into objects based on classes provided by existing R packages. This paper explains the package’s concept and shows how to use it. As an application we present a simple navigation device., 2016-10-20T14:39:46Z, 1, The R Journal, a Eugster, Manuel J and Schlesinger, Thomas, 2012, 53–64</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Harnessing Open Street Map Data with R and QGIS, 2017-02-26T22:16:22Z, EloGeo, EloGeo, Lovelace, Robin, 2014</unstructured_citation></citation><citation key="ref7"><unstructured_citation>osmplotr: Customisable Images of OpenStreetMap Data, Padgham, Mark, 2016, R package version 0.2.3, https://cran.r-project.org/package=osmplotr</unstructured_citation></citation><citation key="ref8"><doi>10.1080/15230406.2016.1176536</doi></citation></citation_list>
       </journal_article>

--- a/joss.00307/10.21105.joss.00307.crossref.xml
+++ b/joss.00307/10.21105.joss.00307.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e1efd0bb83b1f5c1209b132be6681817</doi_batch_id>
-    <timestamp>20171023220231</timestamp>
+    <doi_batch_id>8dcc21350376d759864317f41b17ab34</doi_batch_id>
+    <timestamp>20171024135142</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>307</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.842249</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/307</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00307</item_number>
+          <identifier id_type="doi">10.21105/joss.00307</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.842249</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/307</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00307</doi>
-          <timestamp>20171023220231</timestamp>
+          <timestamp>20171024135142</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00307</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00307/10.21105.joss.00307.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref2"><doi>10.1016/j.cpc.2009.08.005</doi></citation><citation key="ref3"><doi>10.1109/MCSE.2010.118</doi></citation><citation key="ref4"><doi>10.1088/1742-6596/219/3/032057</doi></citation><citation key="ref5"><unstructured_citation>Pedregosa, Fabian and Varoquaux, Gaël and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, Édouard, Scikit-learn: Machine Learning in Python, Journal of Machine Learning Research, 12, 2825-2830, 2011, http://scikit-learn.org</unstructured_citation></citation><citation key="ref6"><unstructured_citation>TensorFlow: Large-Scale Machine Learning on Heterogeneous Systems, http://tensorflow.org/, Martín Abadi and Ashish Agarwal and Paul Barham and Eugene Brevdo and Zhifeng Chen and Craig Citro and Greg S. Corrado and Andy Davis and Jeffrey Dean and Matthieu Devin and Sanjay Ghemawat and Ian Goodfellow and Andrew Harp and Geoffrey Irving and Michael Isard and Jia, Yangqing and Rafal Jozefowicz and Lukasz Kaiser and Manjunath Kudlur and Josh Levenberg and Dan Mané and Rajat Monga and Sherry Moore and Derek Murray and Chris Olah and Mike Schuster and Jonathon Shlens and Benoit Steiner and Ilya Sutskever and Kunal Talwar and Paul Tucker and Vincent Vanhoucke and Vijay Vasudevan and Fernanda Viégas and Oriol Vinyals and Pete Warden and Martin Wattenberg and Martin Wicke and Yuan Yu and Xiaoqiang Zheng, 2015</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00320/10.21105.joss.00320.crossref.xml
+++ b/joss.00320/10.21105.joss.00320.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b2934580d0613e0788c014f331027273</doi_batch_id>
-    <timestamp>20171023220240</timestamp>
+    <doi_batch_id>94817b3bc0bee66e6d7a307541e6f824</doi_batch_id>
+    <timestamp>20171024135143</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>320</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.831969</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/320</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00320</item_number>
+          <identifier id_type="doi">10.21105/joss.00320</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.831969</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/320</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00320</doi>
-          <timestamp>20171023220240</timestamp>
+          <timestamp>20171024135143</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00320</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00320/10.21105.joss.00320.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>pip, https://pip.pypa.io/en/stable/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>bioconda, https://bioconda.github.io/</unstructured_citation></citation><citation key="ref3"><doi>10.1093/bioinformatics/bts480</doi></citation><citation key="ref4"><doi>10.1038/nbt.3772</doi></citation><citation key="ref5"><doi>10.1038/nbt.3820</doi></citation></citation_list>
       </journal_article>

--- a/joss.00331/10.21105.joss.00331.crossref.xml
+++ b/joss.00331/10.21105.joss.00331.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d952e23667fd47dd2cd29edc6f60a425</doi_batch_id>
-    <timestamp>20171023220248</timestamp>
+    <doi_batch_id>b7836616e25d1c4a92151a33a1fcf24a</doi_batch_id>
+    <timestamp>20171024135145</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>331</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.845502</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/331</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00331</item_number>
+          <identifier id_type="doi">10.21105/joss.00331</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.845502</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/331</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00331</doi>
-          <timestamp>20171023220248</timestamp>
+          <timestamp>20171024135145</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00331</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00331/10.21105.joss.00331.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1145/2370036.2145855</doi></citation><citation key="ref2"><doi>10.1137/1.9781611972740.43</doi></citation></citation_list>
       </journal_article>

--- a/joss.00332/10.21105.joss.00332.crossref.xml
+++ b/joss.00332/10.21105.joss.00332.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>60669e47f611ce9592e3ead682491f47</doi_batch_id>
-    <timestamp>20171023220257</timestamp>
+    <doi_batch_id>43757b9834443990277e41b8e38d6afd</doi_batch_id>
+    <timestamp>20171024135146</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>332</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.838248</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/332</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00332</item_number>
+          <identifier id_type="doi">10.21105/joss.00332</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.838248</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/332</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00332</doi>
-          <timestamp>20171023220257</timestamp>
+          <timestamp>20171024135146</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00332</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00332/10.21105.joss.00332.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3390/su7010138</doi></citation><citation key="ref2"><unstructured_citation>ISO 3166-1, Creative Commons Attribution-ShareAlike License, https://en.wikipedia.org/w/index.php?title=ISO_3166-1&oldid=785413591, ISO 3166-1 is part of the ISO 3166 standard published by the International Organization for Standardization (ISO), and defines codes for the names of countries, dependent territories, and special areas of geographical interest. The official name of the standard is Codes for the representation of names of countries and their subdivisions – Part 1: Country codes. It defines three sets of country codes: ISO 3166-1 alpha-2 – two-letter country codes which are the most widely used of the three, and used most prominently for the Internet’s country code top-level domains (with a few exceptions). ISO 3166-1 alpha-3 – three-letter country codes which allow a better visual association between the codes and the country names than the alpha-2 codes. ISO 3166-1 numeric – three-digit country codes which are identical to those developed and maintained by the United Nations Statistics Division, with the advantage of script (writing system) independence, and hence useful for people or systems using non-Latin scripts. The alphabetic country codes were first included in ISO 3166 in 1974, and the numeric country codes were first included in 1981. The country codes have been published as ISO 3166-1 since 1997, when ISO 3166 was expanded into three parts, with ISO 3166-2 defining codes for subdivisions and ISO 3166-3 defining codes for former countries. As a widely used international standard, ISO 3166-1 is implemented in other standards and used by international organizations to allow facilitation of the exchange of goods and information. However, it is not the only standard for country codes. Other country codes used by many international organizations are partly or totally incompatible with ISO 3166-1, although some of them closely correspond to ISO 3166-1 codes., Wikipedia, 2017-07-12, 2017-06-13, english, Page Version ID: 785413591</unstructured_citation></citation><citation key="ref3"><doi>10.1080/09535314.2014.936831</doi></citation><citation key="ref4"><unstructured_citation>The World Input-Output Database (WIOD), http://www.wiod.org/publications/papers/wiod10.pdf, 2013-02-21, Working Paper Number: 10, Timmer, Marcel and Erumban, Abdul A. and Gouma, Reitze and Los, Bart and Temurshoev, Umed and de Vries, Gaaitzen J. and Arto, Iñaki and Genty, Valeria Andreoni Aurélien and Neuwahl, Frederik and Rueda-Cantuche, José M. and Villanueva, Alejandro, 2012, Timmer et al - 2012 - The World Input-Output Database (WIOD).pdf:/home/konstans/zotbib/storage/DSWVEUBZ/Timmer et al - 2012 - The World Input-Output Database (WIOD).pdf:application/pdf</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00333/10.21105.joss.00333.crossref.xml
+++ b/joss.00333/10.21105.joss.00333.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>1f03b5fa377d0362bc83384f856706ff</doi_batch_id>
-    <timestamp>20171023220305</timestamp>
+    <doi_batch_id>035a505e502e7930837125206b122bcb</doi_batch_id>
+    <timestamp>20171024135147</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>333</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.836952</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/333</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00333</item_number>
+          <identifier id_type="doi">10.21105/joss.00333</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.836952</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/333</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00333</doi>
-          <timestamp>20171023220305</timestamp>
+          <timestamp>20171024135147</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00333</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00333/10.21105.joss.00333.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.5281/zenodo.831438</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2017, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><doi>http://dx.doi.org/10.1016/j.ijheh.2017.05.005</doi></citation></citation_list>
       </journal_article>

--- a/joss.00338/10.21105.joss.00338.crossref.xml
+++ b/joss.00338/10.21105.joss.00338.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>78b3d524826f55db9bb7833ef7bd4cba</doi_batch_id>
-    <timestamp>20171023220451</timestamp>
+    <doi_batch_id>b138dc1b4683f7406d9e6621983e5b29</doi_batch_id>
+    <timestamp>20171024135815</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>338</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.835547</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/338</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00338</item_number>
+          <identifier id_type="doi">10.21105/joss.00338</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.835547</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/338</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00338</doi>
-          <timestamp>20171023220451</timestamp>
+          <timestamp>20171024135815</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00338</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00338/10.21105.joss.00338.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list></citation_list>
       </journal_article>

--- a/joss.00339/10.21105.joss.00339.crossref.xml
+++ b/joss.00339/10.21105.joss.00339.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d94dc2a1505276b7ab1e0538983d027d</doi_batch_id>
-    <timestamp>20171023220522</timestamp>
+    <doi_batch_id>9b72c3354eb506f8d04fae83a16403c4</doi_batch_id>
+    <timestamp>20171024135847</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>339</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.848529</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/339</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00339</item_number>
+          <identifier id_type="doi">10.21105/joss.00339</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.848529</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/339</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00339</doi>
-          <timestamp>20171023220522</timestamp>
+          <timestamp>20171024135847</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00339</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00339/10.21105.joss.00339.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Joyce, P. James, Lcopt documentation, https://lcopt.readthedocs.io/en/latest/, 2017-07-24, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Forwast, Forwast - Home, http://forwast.brgm.fr/, 2017-07-24, 2007</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Ronacher, Armin, Flask (A Python Microframework), http://flask.pocoo.org/, 2017-07-24, 2017</unstructured_citation></citation><citation key="ref4"><doi>10.21105/joss.00236</doi></citation><citation key="ref5"><unstructured_citation>Ecoinvent Centre, ecoinvent 3.3, http://www.ecoinvent.org/database/ecoinvent-33/ecoinvent-33.html, 2017-03-28, 2016</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Pre Sustainability, SimaPro 8, 2014</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Joyce, P. James, Lcopt GitHub Repository, https://github.com/pjamesjoyce/lcopt/, 2017</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00340/10.21105.joss.00340.crossref.xml
+++ b/joss.00340/10.21105.joss.00340.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>e9e1a8f009f9174ec4e4b00e0041fc24</doi_batch_id>
-    <timestamp>20171023220531</timestamp>
+    <doi_batch_id>a78410919490960decfefa7f16b1a7a7</doi_batch_id>
+    <timestamp>20171024135848</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>340</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.885362</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/340</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00340</item_number>
+          <identifier id_type="doi">10.21105/joss.00340</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.885362</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/340</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00340</doi>
-          <timestamp>20171023220531</timestamp>
+          <timestamp>20171024135848</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00340</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00340/10.21105.joss.00340.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/j.compchemeng.2017.03.027</doi></citation><citation key="ref2"><unstructured_citation>Harrell, G. K. and McPeak, A. N. and Ford Versypt, A. N., A pharmacokinetic simulation-based module to introduce mass balances and chemical engineering design concepts to engineering freshmen, 2017, Columbus, OH, Proceedings of the ASEE Annual Conference</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00341/10.21105.joss.00341.crossref.xml
+++ b/joss.00341/10.21105.joss.00341.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d3688633bd72c15d1f6ce7009844cbd6</doi_batch_id>
-    <timestamp>20171023220539</timestamp>
+    <doi_batch_id>ea89208dbd0a6d56b719aa1db43e6dfc</doi_batch_id>
+    <timestamp>20171024135849</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>341</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.851892</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/341</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00341</item_number>
+          <identifier id_type="doi">10.21105/joss.00341</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.851892</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/341</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00341</doi>
-          <timestamp>20171023220539</timestamp>
+          <timestamp>20171024135849</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00341</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00341/10.21105.joss.00341.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Inc., Adaptive Computing, TORQUE Resource Manager, 2017, http://www.adaptivecomputing.com/products/open-source/torque/</unstructured_citation></citation><citation key="ref2"><doi>dx.doi.org/10.6084/m9.figshare.3115156.v2</doi></citation><citation key="ref3"><doi>doi.org/10.1093/bioinformatics/btq475</doi></citation><citation key="ref4"><doi>doi.org/10.1093/bioinformatics/bts080</doi></citation></citation_list>
       </journal_article>

--- a/joss.00350/10.21105.joss.00350.crossref.xml
+++ b/joss.00350/10.21105.joss.00350.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>a4839e76f4313e845435a76718381a3c</doi_batch_id>
-    <timestamp>20171023220548</timestamp>
+    <doi_batch_id>143842f19b570892a23e874ed4a9c850</doi_batch_id>
+    <timestamp>20171024135851</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>350</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1009695</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/350</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00350</item_number>
+          <identifier id_type="doi">10.21105/joss.00350</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1009695</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/350</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00350</doi>
-          <timestamp>20171023220548</timestamp>
+          <timestamp>20171024135851</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00350</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00350/10.21105.joss.00350.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Echols, Nat, JavaScript code for X-ray crystallography applications, 2015, https://github.com/natechols/xtal.js/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Wojdyr, Marcin, Macromolecular viewer for crystallographers, 2016, https://github.com/uglymol/uglymol</unstructured_citation></citation><citation key="ref3"><doi>10.1107/s0907444910007493</doi></citation><citation key="ref4"><doi>10.1107/S1600576715004847</doi></citation><citation key="ref5"><unstructured_citation>Wojdyr, Marcin and others, Dimple – macromolecular crystallography pipeline for refinement and ligand screening, 2016, http://ccp4.github.io/dimple/</unstructured_citation></citation><citation key="ref6"><unstructured_citation>de Maria Antolinos, Alejandro and others, Extended User Interface for ISPyB, 2016, https://github.com/ispyb/EXI</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Krissinel, Eugene and Uski, Ville and Lebedev, Andey and Winn, Martyn and Ballard, Charles, Distributed Computing for Macromolecular Crystallography, Acta Crystallographica Section D - Biological Crystallography, submitted</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Minor Lab, University of Virginia, molstack, 2017, http://molstack.bioreproducibility.org</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Hungler, Arnaud and Momin, Afaque and Diederichs, Kay and Arold, Stefan T, ContaMiner and ContaBase: a webserver and database for early identification of unwantedly crystallized protein contaminants, Journal of applied crystallography, 49, 6, 2252–2258, 2016, International Union of Crystallography</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00351/10.21105.joss.00351.crossref.xml
+++ b/joss.00351/10.21105.joss.00351.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>bb65c99b1e1d2a76fec351305bae1948</doi_batch_id>
-    <timestamp>20171023220557</timestamp>
+    <doi_batch_id>f44c2827009764636d0345d02142211d</doi_batch_id>
+    <timestamp>20171024135852</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>351</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.845342</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/351</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00351</item_number>
+          <identifier id_type="doi">10.21105/joss.00351</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.845342</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/351</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00351</doi>
-          <timestamp>20171023220557</timestamp>
+          <timestamp>20171024135852</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00351</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00351/10.21105.joss.00351.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1023/a:1010933404324</doi></citation><citation key="ref2"><doi>10.1186/1297-9686-43-7</doi></citation><citation key="ref3"><doi>10.1007/s10100-017-0479-6</doi></citation><citation key="ref4"><unstructured_citation>, Leo Breiman RF website, 2017, https://www.stat.berkeley.edu/ breiman/RandomForests/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00352/10.21105.joss.00352.crossref.xml
+++ b/joss.00352/10.21105.joss.00352.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>ec83ee9da4ae7cd8d50a81f63fe601ed</doi_batch_id>
-    <timestamp>20171023220608</timestamp>
+    <doi_batch_id>8a976bb7e48badfce03047cd0fd55a8b</doi_batch_id>
+    <timestamp>20171024135853</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>352</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.853160</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/352</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00352</item_number>
+          <identifier id_type="doi">10.21105/joss.00352</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.853160</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/352</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00352</doi>
-          <timestamp>20171023220608</timestamp>
+          <timestamp>20171024135853</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00352</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00352/10.21105.joss.00352.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>https://doi.org/10.1101/092478</doi></citation><citation key="ref2"><doi>https://doi.org/10.1101/162701</doi></citation><citation key="ref3"><unstructured_citation>Snakemake - a scalable bioinformatics workflow engine, Köster, Johannes and Rahmann, Sven, Bioinformatics, 28, 19, 2520–2522, 2012, Oxford University Press</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Kraken: ultrafast metagenomic sequence classification using exact alignments, Wood, Derrick E. and Salzberg, Steven L., Genome Biology, 15:R46, 2014</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00354/10.21105.joss.00354.crossref.xml
+++ b/joss.00354/10.21105.joss.00354.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>fc6637d52cb95e7bb650b3126de52ca3</doi_batch_id>
-    <timestamp>20171023220617</timestamp>
+    <doi_batch_id>ce371ebbf7ad55ff11b57b306a10652a</doi_batch_id>
+    <timestamp>20171024135854</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>354</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.846814</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/354</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00354</item_number>
+          <identifier id_type="doi">10.21105/joss.00354</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.846814</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/354</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00354</doi>
-          <timestamp>20171023220617</timestamp>
+          <timestamp>20171024135854</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00354</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00354/10.21105.joss.00354.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>A (sort of) new image data format standard: Nifti-1, Cox, Robert W and Ashburner, John and Breman, Hester and Fissell, Kate and Haselgrove, Christian and Holmes, Colin J and Lancaster, Jack L and Rex, David E and Smith, Stephen M and Woodward, Jeffrey B and others, Neuroimage, 22, e1440, 2004, https://nifti.nimh.nih.gov/nifti-1/documentation/hbm_nifti_2004.pdf</unstructured_citation></citation><citation key="ref2"><doi>10.1007/s003300101100</doi></citation></citation_list>
       </journal_article>

--- a/joss.00355/10.21105.joss.00355.crossref.xml
+++ b/joss.00355/10.21105.joss.00355.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>eb7b19d05c8416b8d8f24d0eda6e33c1</doi_batch_id>
-    <timestamp>20171023220626</timestamp>
+    <doi_batch_id>605e4d62c4ed0b91d1602e452a548324</doi_batch_id>
+    <timestamp>20171024135856</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>355</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.845960</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/355</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00355</item_number>
+          <identifier id_type="doi">10.21105/joss.00355</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.845960</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/355</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00355</doi>
-          <timestamp>20171023220626</timestamp>
+          <timestamp>20171024135856</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00355</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00355/10.21105.joss.00355.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><unstructured_citation>ggplot2: An Implementation of the Grammar of Graphics, Wickham, Hadley and Chang, Winston and RStudio, 2016, R package version 2.1.0, https://CRAN.R-project.org/package=ggplot2</unstructured_citation></citation><citation key="ref3"><unstructured_citation>R for Data Science, Wickham, Hadley and Grolemund, Garrett, 2016, O’Reilly Media, Inc.</unstructured_citation></citation><citation key="ref4"><unstructured_citation>dplyr: A Grammar of Data Manipulation, Wickham, Hadley and Francois, Romain and Henry, Lionel and Müller, Kirill, 2017, R package version 0.7.2, https://CRAN.R-project.org/package=dplyr</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00357/10.21105.joss.00357.crossref.xml
+++ b/joss.00357/10.21105.joss.00357.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>62af7aecbfe79b1ac2a2e893b524138f</doi_batch_id>
-    <timestamp>20171023220634</timestamp>
+    <doi_batch_id>4025f7dd7c1f9c56f9d1ec6c3c63fcbb</doi_batch_id>
+    <timestamp>20171024135857</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>357</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.885577</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/357</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00357</item_number>
+          <identifier id_type="doi">10.21105/joss.00357</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.885577</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/357</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00357</doi>
-          <timestamp>20171023220634</timestamp>
+          <timestamp>20171024135857</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00357</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00357/10.21105.joss.00357.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Forum, Message P, MPI: A Message-Passing Interface Standard, 1994, http://www.ncstrl.org:8900/ncstrl/servlet/search?formname=detail&id=oai%3Ancstrlh%3Autk_cs%3Ancstrl.utk_cs%2F%2FUT-CS-94-230, University of Tennessee, Knoxville, TN, USA</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Gabriel, Edgar and Fagg, Graham E. and Bosilca, George and Angskun, Thara and Dongarra, Jack J. and Squyres, Jeffrey M. and Sahay, Vishal and Kambadur, Prabhanjan and Barrett, Brian and Lumsdaine, Andrew and Castain, Ralph H. and Daniel, David J. and Graham, Richard L. and Woodall, Timothy S., Open MPI: Goals, Concept, and Design of a Next Generation MPI Implementation, Proceedings, 11th European PVM/MPI Users’ Group Meeting, 2004, Budapest, Hungary, 97–104, sep, 9</unstructured_citation></citation><citation key="ref3"><doi>http://dx.doi.org/10.1016/j.jpdc.2005.03.010</doi></citation><citation key="ref4"><doi>http://dx.doi.org/10.1016/j.jpdc.2007.09.005</doi></citation><citation key="ref5"><unstructured_citation>Lusk, Ewing and Doss, Nathan and Skjellum, Anthony, A high-performance, portable implementation of the MPI message passing interface standard, Parallel Computing, 1996, 22, 789–828</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00359/10.21105.joss.00359.crossref.xml
+++ b/joss.00359/10.21105.joss.00359.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>92193af8b11e77acf5d2353ede9e49fd</doi_batch_id>
-    <timestamp>20171023220644</timestamp>
+    <doi_batch_id>e39a41defacf66c0f97789caa08083f8</doi_batch_id>
+    <timestamp>20171024135858</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>359</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.841331</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/359</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00359</item_number>
+          <identifier id_type="doi">10.21105/joss.00359</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.841331</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/359</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00359</doi>
-          <timestamp>20171023220644</timestamp>
+          <timestamp>20171024135858</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00359</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00359/10.21105.joss.00359.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R language definition, Team, R Core, Vienna, Austria: R foundation for statistical computing, 2000</unstructured_citation></citation><citation key="ref2"><doi>https://doi.org/10.1093/bioinformatics/btw313</doi></citation><citation key="ref3"><unstructured_citation>d3heatmap: Interactive Heat Maps Using ’htmlwidgets’ and ’D3.js’, Cheng, Joe and Galili, Tal, 2016, R package version 0.6.1.1, https://CRAN.R-project.org/package=d3heatmap</unstructured_citation></citation><citation key="ref4"><unstructured_citation>heatmaply: Interactive Heat Maps Using ’plotly’, Galili, Tal, 2016, R package version 0.5.0, https://CRAN.R-project.org/package=heatmaply</unstructured_citation></citation><citation key="ref5"><unstructured_citation>plotly: Create Interactive Web Graphics via ’plotly.js’, Sievert, Carson and Parmer, Chris and Hocking, Toby and Chamberlain, Scott and Ram, Karthik and Corvellec, Marianne and Despouy, Pedro, 2016, R package version 4.5.2, https://CRAN.R-project.org/package=plotly</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00363/10.21105.joss.00363.crossref.xml
+++ b/joss.00363/10.21105.joss.00363.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7a64505fc36715d296456a2b2755dd75</doi_batch_id>
-    <timestamp>20171023220653</timestamp>
+    <doi_batch_id>be1c336301a9c817274c5d1ab579a639</doi_batch_id>
+    <timestamp>20171024135900</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>363</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.845455</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/363</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00363</item_number>
+          <identifier id_type="doi">10.21105/joss.00363</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.845455</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/363</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00363</doi>
-          <timestamp>20171023220653</timestamp>
+          <timestamp>20171024135900</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00363</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00363/10.21105.joss.00363.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref2"><unstructured_citation>Sommer, Philipp S, The psyplot interactive visualization framework, 2017, https://github.com/Chilipp/psyplot, 2017-07-28</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Sommer, Philipp S, psy-simple: The psyplot plugin for simple visualizations, 2017, https://github.com/Chilipp/psy-simple, 2017-07-28</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Sommer, Philipp S, psy-maps: The psyplot plugin for visualizations on a map, 2017, https://github.com/Chilipp/psy-maps, 2017-07-28</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Sommer, Philipp S, psy-reg: Psyplot plugin for visualizing and calculating regression plot, 2017, https://github.com/Chilipp/psy-reg, 2017-07-28</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Sommer, Philipp S, Graphical User Interface for the psyplot package, 2017, https://github.com/Chilipp/psyplot-gui, 2017-07-28</unstructured_citation></citation><citation key="ref7"><doi>10.5334/jors.148</doi></citation></citation_list>
       </journal_article>

--- a/joss.00365/10.21105.joss.00365.crossref.xml
+++ b/joss.00365/10.21105.joss.00365.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>43412c39fe83a6c612210a75a7c16a44</doi_batch_id>
-    <timestamp>20171023220701</timestamp>
+    <doi_batch_id>9fb71d32d1f1205c5b9fc5ba68ac602e</doi_batch_id>
+    <timestamp>20171024135901</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>365</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1012627</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/365</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00365</item_number>
+          <identifier id_type="doi">10.21105/joss.00365</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1012627</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/365</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00365</doi>
-          <timestamp>20171023220701</timestamp>
+          <timestamp>20171024135901</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00365</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00365/10.21105.joss.00365.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Bishop, Christopher, Pattern Recognition and Machine Learning, Springer, 2006</unstructured_citation></citation><citation key="ref2"><doi>10.1109/79.543975</doi></citation><citation key="ref3"><unstructured_citation>McLachlan, Geoffrey and Krishnan, Thriyambakam, The EM Algorithm and Extensions, 2nd, John Wiley & Sons, 2008</unstructured_citation></citation><citation key="ref4"><doi>10.21105/joss.00026</doi></citation><citation key="ref5"><doi>10.1145/1327452.1327492</doi></citation><citation key="ref6"><unstructured_citation>Chapman, Barbara and Jost, Gabriele and van der Pas, Ruud, Using OpenMP: Portable Shared Memory Parallel Programming, MIT Press, 2007</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Sanderson, Conrad and Curtin, Ryan, An Open Source C++ Implementation of Multi-Threaded Gaussian Mixture Models, k-Means and Expectation Maximisation, arXiv:1707.09094, 2017</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00366/10.21105.joss.00366.crossref.xml
+++ b/joss.00366/10.21105.joss.00366.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>27e22dc9fc8f8cd04af87bc12b2dc189</doi_batch_id>
-    <timestamp>20171023220710</timestamp>
+    <doi_batch_id>46d32d4ae0f71ba9950b972e943faa13</doi_batch_id>
+    <timestamp>20171024135902</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>366</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.848749</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/366</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00366</item_number>
+          <identifier id_type="doi">10.21105/joss.00366</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.848749</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/366</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00366</doi>
-          <timestamp>20171023220710</timestamp>
+          <timestamp>20171024135902</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00366</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00366/10.21105.joss.00366.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Celery: Distributed Task Queue, Celery, http://www.celeryproject.org</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Django Channels, Channels, https://github.com/django/channels</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Django Web Application Framework, Django, https://www.djangoproject.com/</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Django Remote Submission, django-remote-submission, https://github.com/ornl-ndav/django-remote-submission</unstructured_citation></citation><citation key="ref5"><doi>10.5281/zenodo.260178</doi></citation><citation key="ref6"><unstructured_citation>Refl1D: Interactive depth profile modeler, Kienzle, PA and Krycka, JA and Patel, N, https://github.com/reflectometry/refl1d</unstructured_citation></citation><citation key="ref7"><doi>http://dx.doi.org/10.1016/j.physb.2006.05.281</doi></citation><citation key="ref8"><unstructured_citation>PyPI - the Python Package Index, PyPi, https://pypi.python.org/pypi/django-remote-submission</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Redis, Redis, https://redis.io</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00368/10.21105.joss.00368.crossref.xml
+++ b/joss.00368/10.21105.joss.00368.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>46de75a894412186cb0a0d8dcfeabb0f</doi_batch_id>
-    <timestamp>20171023220719</timestamp>
+    <doi_batch_id>93a55bddec26478b87afdba591be794f</doi_batch_id>
+    <timestamp>20171024135903</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>368</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.853423</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/368</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00368</item_number>
+          <identifier id_type="doi">10.21105/joss.00368</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.853423</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/368</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00368</doi>
-          <timestamp>20171023220719</timestamp>
+          <timestamp>20171024135903</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00368</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00368/10.21105.joss.00368.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1029/92JC01511</doi></citation><citation key="ref2"><doi>10.1029/2010GB003868</doi></citation><citation key="ref3"><doi>10.5194/bg-9-3231-2012</doi></citation><citation key="ref4"><doi>10.5194/bg-10-281-2013</doi></citation><citation key="ref5"><doi>10.5194/essd-5-295-2013</doi></citation><citation key="ref6"><doi>10.1594/PANGAEA.809717</doi></citation><citation key="ref7"><doi>10.1016/j.epsl.2013.03.008</doi></citation><citation key="ref8"><doi>10.1016/j.marchem.2014.08.007</doi></citation><citation key="ref9"><doi>10.1016/j.dsr2.2014.11.020</doi></citation><citation key="ref10"><doi>10.1016/j.dsr2.2014.07.007</doi></citation><citation key="ref11"><doi>10.1016/j.marchem.2015.01.006</doi></citation><citation key="ref12"><doi>10.1016/j.marchem.2015.04.005</doi></citation><citation key="ref13"><doi>10.5194/gmd-8-2465-2015</doi></citation><citation key="ref14"><doi>10.5194/bg-14-2321-2017</doi></citation><citation key="ref15"><unstructured_citation>NEMO ocean engine, version 3.6 stable, , Institut Pierre-Simon Laplace (IPSL), Note du Pole de Modélisation, 1288-1619, 2016, access:open</unstructured_citation></citation><citation key="ref16"><doi>10.1016/j.jmarsys.2012.05.005</doi></citation><citation key="ref17"><doi>10.5194/bg-14-1123-2017</doi></citation><citation key="ref18"><doi>10.1594/PANGAEA.871981</doi></citation><citation key="ref19"><doi>10.1029/2000JD900719</doi></citation><citation key="ref20"><doi>10.1016/0304-3800(81)90034-X</doi></citation><citation key="ref21"><doi>10.1016/j.jmarsys.2008.03.011</doi></citation><citation key="ref22"><unstructured_citation>A strategy and a tool, Ferret, for closely integrated visualization and analysis, Hankin, S. and Harrison, D.E. and Osborne, J. and Davidson, J. and Obrien, K., Journal of Visualization and Computer Animation, 7, 3, 149–157, 1996, http://ferret.pmel.noaa.gov/static/Documentation/rostock_paper/paper.html, access:open, licence:proprietary</unstructured_citation></citation><citation key="ref23"><doi>10.1109/MCSE.2007.55</doi></citation><citation key="ref24"><unstructured_citation>ggplot2: Elegant Graphics for Data Analysis, W., Hadley, 2016, Springer, 978-0387981406, http://ggplot2.org/, access:closed</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00370/10.21105.joss.00370.crossref.xml
+++ b/joss.00370/10.21105.joss.00370.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>9a9a20c908c4f6749e77cbb9eb40610f</doi_batch_id>
-    <timestamp>20171023220728</timestamp>
+    <doi_batch_id>b3dd057f52f52205f4769346041c7d82</doi_batch_id>
+    <timestamp>20171024135904</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>370</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.845328</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/370</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00370</item_number>
+          <identifier id_type="doi">10.21105/joss.00370</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.845328</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/370</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00370</doi>
-          <timestamp>20171023220728</timestamp>
+          <timestamp>20171024135904</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00370</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00370/10.21105.joss.00370.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Grau-Crespo, R. and Hamad, S. and Catlow, C. Richard A. and de Leeuw, N. H., Symmetry-adapted configurational modelling of fractional site occupancy in solids, J. Phys.-Condens. Mat., 2007, 19, 25, 256201</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Ong, Shyue Ping and Richards, William Davidson and Jain, Anubhav and Hautier, Geoffroy and Kocher, Michael and Cholia, Shreyas and Gunter, Dan and Chevrier, Vincent L and Persson, Kristin A and Ceder, Gerbrand, Python Materials Genomics (pymatgen): A robust, open-source Python library for materials analysis, Comp. Mater. Sci., 2013, 68, C, 314–319, feb, 2</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Morgan, Benjamin J., 2016-01-15, 2016-07-15 10:28:25 +0000, 2017-07-02 18:49:38 +0000, \textttbsym - A Basic Symmetry Module, 22/07/17, https://github.com/bjmorgan/bsym, 10.5281/zenodo.833875</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Ludwig, Christian D. R. and Gruhn, Thomas and Felser, Claudia and Windeln, Johannes, 2017-07-25 12:49:40 +0000, 2017-07-25 12:49:54 +0000, Phys. Rev. B, may, 17, 622–8, Defect structures in CuInSe_2: A combination of Monte Carlo simulations and density functional theory, 83, 2011, 5</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Ganose, Alex M. and Scanlon, David O., 2017-07-25 10:59:19 +0000, 2017-07-25 10:59:32 +0000, J. Mater. Chem. A, feb, 1467–1475, Band gap and work function tailoring of SnO_2 for improved transparent conducting ability in photovoltaics, 4, 2016, 2</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Morgan, Benjamin J. and Watson, Graeme W., 2012-04-02 17:49:13 +0000, 2015-11-16 08:26:50 +0000, J. Phys. Chem. Lett., jun, 1657—1611, The Role of Lithium Ordering in the Li_xTiO_2 Anatase \to Titanate Phase Transition, 2, 2011, 6</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Grieshammer, Steffen and Grope, Benjamin O. H. and Koettgen, Julius and Martin, Manfred, 2017-07-25 13:19:16 +0000, 2017-07-25 13:19:32 +0000, Phys. Chem. Chem. Phys., 21, 9974–13, A combined DFT+U and Monte Carlo study on rare earth doped ceria, 16, 2014</unstructured_citation></citation><citation key="ref8"><unstructured_citation>Dalton, Andrew S. and Belak, Anna A. and Van Der Ven, Anton, 2012-05-22 16:18:00 +0000, 2012-05-22 16:18:24 +0000, Chem. Mater., apr, 1568–1574, Thermodynamics of Lithium in TiO_2(B) from First Principles, 24, 2012, 4</unstructured_citation></citation><citation key="ref9"><unstructured_citation>Zunger, A. and Wei, S.H. and Ferreria, L. G. and Bernard, J. E., 2017-07-25 06:16:03 +0000, 2017-07-25 06:16:38 +0000, Phys. Rev. Lett., 3, 353–356, Special Quasirandom Structures, 65, 1990</unstructured_citation></citation><citation key="ref10"><unstructured_citation>van de Walle, A. and Ceder, Gerbrand, 2017-07-25 06:17:48 +0000, 2017-07-25 13:21:33 +0000, J. Phase Equil., aug, 4, 348–359, Automating first-principles phase diagram calculations, 23, 2002, 8</unstructured_citation></citation><citation key="ref11"><doi>10.5281/zenodo.546148</doi></citation><citation key="ref12"><unstructured_citation>Tompsett, David A. and Islam, M. Saiful, 2017-07-25 06:34:44 +0000, 2017-07-25 06:35:08 +0000, Chem. Mater., jun, 12, 2515–2526, Electrochemistry of Hollandite α-MnO_2: Li-Ion and Na-Ion Insertion and Li_2O Incorporation, 25, 2013, 6</unstructured_citation></citation><citation key="ref13"><unstructured_citation>Morgan, Benjamin J. and Carrasco, Javier and Teobaldi, Gilberto, 2017-04-03 11:28:26 +0000, 2017-04-03 11:28:26 +0000, J. Mater. Chem. A, oct, 43, 17180–17192, Variation in surface energy and reduction drive of a metal oxide lithium-ion anode with stoichiometry: a DFT study of lithium titanate spinel surfaces, 4, 2016, 10</unstructured_citation></citation><citation key="ref14"><unstructured_citation>Lerch, D. and Wieckhorst, O. and Hart, G. L. W. and Forcade, R. W. and Müller, S., 2017-08-18 10:07:39 +0000, 2017-08-18 10:07:39 +0000, Modelling Simul. Mater. Sci. Eng., jun, 5, 055003–20, UNCLE: a code for constructing cluster expansions for arbitrary lattices with minimal user-input, 17, 2009, 6</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00371/10.21105.joss.00371.crossref.xml
+++ b/joss.00371/10.21105.joss.00371.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>298963b6538dc3e93bab79584bbdafa5</doi_batch_id>
-    <timestamp>20171023220737</timestamp>
+    <doi_batch_id>3f7861c69a0c03afed66fe2ffb73cd8d</doi_batch_id>
+    <timestamp>20171024135906</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>371</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1004765</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/371</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00371</item_number>
+          <identifier id_type="doi">10.21105/joss.00371</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1004765</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/371</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00371</doi>
-          <timestamp>20171023220737</timestamp>
+          <timestamp>20171024135906</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00371</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00371/10.21105.joss.00371.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3982/ECTA13408</doi></citation><citation key="ref2"><doi>10.1111/1467-937X.00246</doi></citation><citation key="ref3"><doi>10.2307/2171831</doi></citation><citation key="ref4"><doi>10.1016/j.econlet.2009.04.026</doi></citation><citation key="ref5"><unstructured_citation>Production Function Estimation in R: The prodest package., Rovigatti, G, R package, 0.1.1, https://cran.r-project.org/package=prodest.</unstructured_citation></citation><citation key="ref6"><unstructured_citation>prodest, Rovigatti, G, https://github.com/GabrieleRovigatti/prodest/tree/master/prodest</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00372/10.21105.joss.00372.crossref.xml
+++ b/joss.00372/10.21105.joss.00372.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>4f05ecab9b4b1ecba801b96b2d374179</doi_batch_id>
-    <timestamp>20171023220745</timestamp>
+    <doi_batch_id>1d364c581e57d695511c6b97dad17df4</doi_batch_id>
+    <timestamp>20171024135907</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>372</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.887895</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/372</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00372</item_number>
+          <identifier id_type="doi">10.21105/joss.00372</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.887895</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/372</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00372</doi>
-          <timestamp>20171023220745</timestamp>
+          <timestamp>20171024135907</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00372</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00372/10.21105.joss.00372.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.1016/S0168-9002(97)00048-X</doi></citation><citation key="ref2"><doi>10.1016/j.cpc.2006.11.010</doi></citation><citation key="ref3"><doi>10.1088/1126-6708/2004/07/036</doi></citation><citation key="ref4"><unstructured_citation>Dobbs, M and Hansen, J B, The HepMC C++ Monte Carlo Event Record for High Energy Physics, CERN, ATL-SOFT-2000-001, jun, 2000, http://cds.cern.ch/record/684090, 6</unstructured_citation></citation><citation key="ref5"><unstructured_citation>authors, The Gonum, Gonum: consistent, composable and comprehensible scientific code, https://gonum.org</unstructured_citation></citation><citation key="ref6"><unstructured_citation>authors, The YODA, YODA: Yet more Objects for Data Analysis, https://yoda.hepforge.org</unstructured_citation></citation><citation key="ref7"><doi>10.1007/JHEP02(2014)057</doi></citation><citation key="ref8"><doi>10.1140/epjc/s10052-012-1896-2</doi></citation><citation key="ref9"><unstructured_citation>authors, The LCIO, Linear Collider I/O, https://github.com/iLCSoft/LCIO</unstructured_citation></citation><citation key="ref10"><unstructured_citation>Kern, Robert, A simple file format for NumPy arrays, https://docs.scipy.org/doc/numpy/neps/npy-format.html</unstructured_citation></citation><citation key="ref11"><unstructured_citation>Authors, The Go, The Go programming language, https://golang.org</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00373/10.21105.joss.00373.crossref.xml
+++ b/joss.00373/10.21105.joss.00373.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>d1bac6b1c820c6e291fe759d3c0ed127</doi_batch_id>
-    <timestamp>20171023220754</timestamp>
+    <doi_batch_id>4904f958998a2797e250e328f7a37ecd</doi_batch_id>
+    <timestamp>20171024135908</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>373</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.889080</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/373</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00373</item_number>
+          <identifier id_type="doi">10.21105/joss.00373</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.889080</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/373</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00373</doi>
-          <timestamp>20171023220754</timestamp>
+          <timestamp>20171024135908</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00373</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00373/10.21105.joss.00373.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>array_split documentation, Latham, Shane J., http://array-split.readthedocs.io/en/latest/, 2017-08-01, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>multiprocessing – Process-based parallelism, https://docs.python.org/3/library/multiprocessing.html, 2017-08-01, 2017</unstructured_citation></citation><citation key="ref3"><doi>10.1109/MCSE.2011.37</doi></citation><citation key="ref4"><doi>10.7717/peerj.453</doi></citation><citation key="ref5"><doi>10.1016/j.advwatres.2011.04.013</doi></citation><citation key="ref6"><doi>10.1016/j.parco.2011.09.001</doi></citation><citation key="ref7"><unstructured_citation>The HDF Group, Hierarchical Data Format, version 5, 1997-NNNN, http://www.hdfgroup.org/HDF5/</unstructured_citation></citation><citation key="ref8"><unstructured_citation>python, hdf5, 2013, O’Reilly, Python and HDF5, Collette, Andrew, 9781491945018</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00374/10.21105.joss.00374.crossref.xml
+++ b/joss.00374/10.21105.joss.00374.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>b2a33ff62f434a24128174dbb8e06856</doi_batch_id>
-    <timestamp>20171023220802</timestamp>
+    <doi_batch_id>e6dfdd28bda43b5d14a54c8687ab82f8</doi_batch_id>
+    <timestamp>20171024135909</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>374</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.894402</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/374</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00374</item_number>
+          <identifier id_type="doi">10.21105/joss.00374</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.894402</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/374</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00374</doi>
-          <timestamp>20171023220802</timestamp>
+          <timestamp>20171024135909</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00374</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00374/10.21105.joss.00374.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2017, https://www.R-project.org/</unstructured_citation></citation><citation key="ref2"><doi>10.1109/CEC.2001.934439</doi></citation><citation key="ref3"><unstructured_citation>Bossek, J. and Grimme, C., Proceedings of the 2017 IEEE Symposium Series on Computational Intelligence (accepted), A Pareto-Beneficial Sub-Tree Mutation for the Multi-Criteria Minimum Spanning Tree Problem, 2017</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Prüfer, H., Neuer Beweis eines Satzes über Permutationen., Arch. Math. Phys., 27, 742–744, 1918</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Deb, K., Multi-Objective Optimization Using Evolutionary Algorithms, 2001, 047187339X, John Wiley & Sons, Inc., New York, NY, USA</unstructured_citation></citation><citation key="ref6"><doi>https://doi.org/10.1016/S0377-2217(98)00016-2</doi></citation><citation key="ref7"><doi>10.1002/j.1538-7305.1957.tb01515.x</doi></citation></citation_list>
       </journal_article>

--- a/joss.00382/10.21105.joss.00382.crossref.xml
+++ b/joss.00382/10.21105.joss.00382.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>7b4c4af7237d350d46483ee132bed6df</doi_batch_id>
-    <timestamp>20171023220810</timestamp>
+    <doi_batch_id>3edd3fae915f4e20a624f9917bbb8a0a</doi_batch_id>
+    <timestamp>20171024135910</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>382</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.888108</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/382</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00382</item_number>
+          <identifier id_type="doi">10.21105/joss.00382</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.888108</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/382</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00382</doi>
-          <timestamp>20171023220810</timestamp>
+          <timestamp>20171024135910</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00382</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00382/10.21105.joss.00382.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Python for scientific computing, Oliphant, Travis E, Computing in Science & Engineering, 9, 3, 2007, IEEE</unstructured_citation></citation><citation key="ref2"><unstructured_citation>The NumPy array: a structure for efficient numerical computation, Walt, Stéfan van der and Colbert, S Chris and Varoquaux, Gael, Computing in Science & Engineering, 13, 2, 22–30, 2011, IEEE</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Thickness network features for prognostic applications in dementia, Raamana, Pradeep Reddy and Weiner, Michael W and Wang, Lei and Beg, Mirza Faisal and Initiative, Alzheimer’s Disease Neuroimaging and others, Neurobiology of aging, 36, S91–S102, 2015, Elsevier</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00384/10.21105.joss.00384.crossref.xml
+++ b/joss.00384/10.21105.joss.00384.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>5d3ed15c0394df6eb1cf159561b26265</doi_batch_id>
-    <timestamp>20171023220819</timestamp>
+    <doi_batch_id>b8d590875c1cc04d271c7bfe65f3f944</doi_batch_id>
+    <timestamp>20171024135912</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>384</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1002225</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/384</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00384</item_number>
+          <identifier id_type="doi">10.21105/joss.00384</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1002225</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/384</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00384</doi>
-          <timestamp>20171023220819</timestamp>
+          <timestamp>20171024135912</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00384</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00384/10.21105.joss.00384.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>of Housing, US Department and Development, Urban, HMIS Data Standards Data Dictionary, US Department of Housing and Urban Development, https://www.hudexchange.info/resource/3824/hmis-data-dictionary/, 2017</unstructured_citation></citation><citation key="ref2"><unstructured_citation>of Housing, US Department and Development, Urban, HMIS Data Standards Data Manual, US Department of Housing and Urban Development, https://www.hudexchange.info/resources/documents/HMIS-Data-Standards-Manual.pdf, 2016</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00388/10.21105.joss.00388.crossref.xml
+++ b/joss.00388/10.21105.joss.00388.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>12d180c3a6131c12fc891be5aa9f9a98</doi_batch_id>
-    <timestamp>20171023220827</timestamp>
+    <doi_batch_id>8cab97f86ef4aadc798a3f5e02b11c94</doi_batch_id>
+    <timestamp>20171024135913</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>388</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1004642</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/388</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00388</item_number>
+          <identifier id_type="doi">10.21105/joss.00388</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1004642</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/388</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00388</doi>
-          <timestamp>20171023220827</timestamp>
+          <timestamp>20171024135913</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00388</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00388/10.21105.joss.00388.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Provided by the SAO/NASA Astrophysics Data System, http://adsabs.harvard.edu/abs/2017arXiv170304627P, arXiv, Pearson, S. and Price-Whelan, A. M. and Johnston, K. V., 1703.04627, ArXiv e-prints, Astrophysics - Astrophysics of Galaxies, mar, Gaps in Globular Cluster Streams: Pal 5 and the Galactic Bar, 2017, 3</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Provided by the SAO/NASA Astrophysics Data System, http://adsabs.harvard.edu/abs/2008gady.book.....B, Binney, J. and Tremaine, S., Galactic Dynamics: Second Edition, by James Binney and Scott Tremaine. ISBN 978-0-691-13026-2 (HB). Published by Princeton University Press, Princeton, NJ USA, 2008., Princeton University Press, Galactic Dynamics: Second Edition, 2008</unstructured_citation></citation><citation key="ref3"><doi>10.5281/zenodo.833339</doi></citation><citation key="ref4"><doi>10.1051/0004-6361/201629272</doi></citation><citation key="ref5"><doi>10.1051/0004-6361/201322068</doi></citation></citation_list>
       </journal_article>

--- a/joss.00396/10.21105.joss.00396.crossref.xml
+++ b/joss.00396/10.21105.joss.00396.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>be2230c14128a816b5bc64cd2b7bd162</doi_batch_id>
-    <timestamp>20171023220836</timestamp>
+    <doi_batch_id>892680941177891df8b4cebd31b97d13</doi_batch_id>
+    <timestamp>20171024135914</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>396</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.896706</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/396</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00396</item_number>
+          <identifier id_type="doi">10.21105/joss.00396</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.896706</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/396</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00396</doi>
-          <timestamp>20171023220836</timestamp>
+          <timestamp>20171024135914</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00396</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00396/10.21105.joss.00396.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>The MathWorks, Inc., Simulink - Simulation and model-based design, https://www.mathworks.com/products/simulink.html</unstructured_citation></citation><citation key="ref2"><unstructured_citation>The MathWorks, Inc., Matlab - The language of technical computing, https://www.mathworks.com/products/matlab.html</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Margolis, Benjamin W. L. and Ayoubi, Mohammad A., Model Predictive Control of Planetary Aerocapture Using Takagi-Sugeno Fuzzy Model, 26th AAS/AIAA Space Flight Mechanics Meeting, Napa, CA, 2016, feb, 2</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Margolis, Benjamin W. L. and Ayoubi, Mohammad A., Comparative Study of Tracking Controllers Applied to Martian Aerocapture, AAS/AIAA Astrodynamics Specialist Conference, Columbia River Gorge, Stevenson, WA, 2017, aug, 8</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00401/10.21105.joss.00401.crossref.xml
+++ b/joss.00401/10.21105.joss.00401.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>c4e2e5f5b5b7f9c96afa9d2cea58d8be</doi_batch_id>
-    <timestamp>20171023220844</timestamp>
+    <doi_batch_id>919fd53a31bf28e65f263f2fc460586d</doi_batch_id>
+    <timestamp>20171024135915</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>401</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.910866</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/401</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00401</item_number>
+          <identifier id_type="doi">10.21105/joss.00401</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.910866</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/401</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00401</doi>
-          <timestamp>20171023220844</timestamp>
+          <timestamp>20171024135915</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00401</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00401/10.21105.joss.00401.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Kessler, Travis, ECNet: Large scale machine learning projects for fuel property prediction, 2017, https://github.com/TJKessler/ECNet, 2017-10-04</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Kessler, Travis, ECNet 1.2.5.dev1, 2017, https://pypi.python.org/pypi/ecnet/, 2017-10-04</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Mack, John Hunter, Energy and Combustion Research Laboratory, 2017, http://faculty.uml.edu/Hunter_Mack/, 2017-10-04</unstructured_citation></citation><citation key="ref4"><doi>10.1115/ICEF2013-19185</doi></citation><citation key="ref5"><doi>10.1115/ICEF2016-9383</doi></citation><citation key="ref6"><doi>10.1016/j.fuel.2017.06.015</doi></citation></citation_list>
       </journal_article>

--- a/joss.00402/10.21105.joss.00402.crossref.xml
+++ b/joss.00402/10.21105.joss.00402.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>163b05d404a63c54bb1a2ef528b195ab</doi_batch_id>
-    <timestamp>20171023220853</timestamp>
+    <doi_batch_id>77f5252802a821c7cdc25fb318d66ff3</doi_batch_id>
+    <timestamp>20171024135917</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>402</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.889710</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/402</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00402</item_number>
+          <identifier id_type="doi">10.21105/joss.00402</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.889710</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/402</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00402</doi>
-          <timestamp>20171023220853</timestamp>
+          <timestamp>20171024135917</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00402</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00402/10.21105.joss.00402.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Kane, Michael J., bittrex: An R client for the Bittrex Crypto-Currency Exchange, 2017, R package version 0.1.0, https://github.com/kaneplusplus/bittrex, 2017-06-02</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Bittrex Crypto-Currency Exchange, https://bittrex.com/, 2017-06-02</unstructured_citation></citation><citation key="ref3"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2017, https://www.R-project.org/</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00411/10.21105.joss.00411.crossref.xml
+++ b/joss.00411/10.21105.joss.00411.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>3336c4a57afb1f57005457bde6cafdaa</doi_batch_id>
-    <timestamp>20171023220901</timestamp>
+    <doi_batch_id>ead4db043a4c5f364aa460256271b828</doi_batch_id>
+    <timestamp>20171024135918</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>411</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.897183</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/411</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00411</item_number>
+          <identifier id_type="doi">10.21105/joss.00411</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.897183</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/411</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00411</doi>
-          <timestamp>20171023220901</timestamp>
+          <timestamp>20171024135918</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00411</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00411/10.21105.joss.00411.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Australian Bureau of Meteorology, Weather Data Services, may, 2017, 2017-05-16 04:06:56 +0000, 2017-05-16 04:07:29 +0000, BoM, Weather, Australia, 16/05/2017, http://www.bom.gov.au/catalogue/data-feeds.shtml, 5</unstructured_citation></citation><citation key="ref2"><unstructured_citation>Vienna, Austria, R Core Team, R Foundation for Statistical Computing, R: A Language and Environment for Statistical Computing, https://www.R-project.org/, 2017, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><doi>10.18637/jss.v059.i10</doi></citation><citation key="ref4"><doi>http://dx.doi.org/10.1016/S1474-7065(02)00140-7</doi></citation><citation key="ref5"><doi>http://dx.doi.org/10.1016/j.rser.2005.12.002</doi></citation><citation key="ref6"><doi>http://dx.doi.org/10.1016/j.landurbplan.2008.10.006</doi></citation><citation key="ref7"><doi>http://dx.doi.org/10.1016/S0169-2046(02)00076-2</doi></citation><citation key="ref8"><doi>10.1094/PHYTO.2003.93.4.428</doi></citation><citation key="ref9"><unstructured_citation>WINS: Crop Stress Weather Information Delivery System in R, 2017, Sparks, Adam and Pembleton, Keith and Grundy, Gordon, R package version 0.0.1.9000, https://github.com/ToowoombaTrio/WINS</unstructured_citation></citation></citation_list>
       </journal_article>

--- a/joss.00412/10.21105.joss.00412.crossref.xml
+++ b/joss.00412/10.21105.joss.00412.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>56b62766c93f30661772d85cd39cf330</doi_batch_id>
-    <timestamp>20171023220911</timestamp>
+    <doi_batch_id>bdf9e19937da09519d09245bc7593538</doi_batch_id>
+    <timestamp>20171024135919</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>412</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1013318</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/412</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00412</item_number>
+          <identifier id_type="doi">10.21105/joss.00412</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1013318</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/412</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00412</doi>
-          <timestamp>20171023220911</timestamp>
+          <timestamp>20171024135919</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00412</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00412/10.21105.joss.00412.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>GeneXplain — Identification of Causal Biomarkers and Drug Targets in Personalized Cancer Pathways, Kel, A. and Kolpakov, F. and Poroikov, V. and Selivanova, G., J. Biomol. Tech., 22, S1, 2011</unstructured_citation></citation><citation key="ref2"><doi>10.3390/microarrays4020270</doi></citation><citation key="ref3"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref4"><unstructured_citation>rbiouml: Interact with BioUML Server, Yevshin, Ivan and Valeev, Tagir, 2013, R package version 1.7</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Stegmaier, Philip, genexplain-api - The geneXplain platform Java API, 2017, GitHub, GitHub repository, \urlhttps://github.com/genexplain/genexplain-api</unstructured_citation></citation><citation key="ref6"><doi>10.1186/gb-2004-5-10-r80</doi></citation><citation key="ref7"><doi>10.1038/75556</doi></citation><citation key="ref8"><doi>10.1073/pnas.0506580102</doi></citation><citation key="ref9"><doi>10.1073/pnas.0610772104</doi></citation><citation key="ref10"><doi>10.1093/nar/gkv007</doi></citation><citation key="ref11"><doi>10.1186/gb-2010-11-10-r106</doi></citation><citation key="ref12"><doi>10.1093/nar/gkj092</doi></citation></citation_list>
       </journal_article>

--- a/joss.00417/10.21105.joss.00417.crossref.xml
+++ b/joss.00417/10.21105.joss.00417.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>f9185c5e55d18d9f03c8f7119b77c35f</doi_batch_id>
-    <timestamp>20171023220920</timestamp>
+    <doi_batch_id>5f3fd606643c2ad43944923817d71a25</doi_batch_id>
+    <timestamp>20171024135920</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>417</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.6084/m9.figshare.5469208</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/417</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00417</item_number>
+          <identifier id_type="doi">10.21105/joss.00417</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.6084/m9.figshare.5469208</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/417</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00417</doi>
-          <timestamp>20171023220920</timestamp>
+          <timestamp>20171024135920</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00417</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00417/10.21105.joss.00417.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>10.3945/jn.113.183079</doi></citation><citation key="ref2"><unstructured_citation>R: A Language and Environment for Statistical Computing, R Core Team, R Foundation for Statistical Computing, Vienna, Austria, 2016, https://www.R-project.org/</unstructured_citation></citation><citation key="ref3"><unstructured_citation>nhanesA: NHANES Data Retrieval, Endres, Christopher, 2016, R package version 0.6.4.3.3, https://CRAN.R-project.org/package=nhanesA</unstructured_citation></citation><citation key="ref4"><doi>10.1080/14992027.2017.1331049</doi></citation><citation key="ref5"><doi>10.1016/j.jand.2017.03.018</doi></citation><citation key="ref6"><doi>10.5888/pcd14.170004</doi></citation></citation_list>
       </journal_article>

--- a/joss.00424/10.21105.joss.00424.crossref.xml
+++ b/joss.00424/10.21105.joss.00424.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>687c54e555e21be57273db30ca597840</doi_batch_id>
-    <timestamp>20171023220929</timestamp>
+    <doi_batch_id>a37f247253bddb68597724077037a15f</doi_batch_id>
+    <timestamp>20171024135921</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>424</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1003184</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/424</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00424</item_number>
+          <identifier id_type="doi">10.21105/joss.00424</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1003184</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/424</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00424</doi>
-          <timestamp>20171023220929</timestamp>
+          <timestamp>20171024135921</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00424</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00424/10.21105.joss.00424.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><unstructured_citation>Heusser, Andrew C. and Fitzpatrick, Paxton C. and Field, Campbell E. and Ziman, Kirsten and Manning, Jeremy R., Quail Documentation, http://cdl-quail.readthedocs.io/en/latest/, 2017</unstructured_citation></citation><citation key="ref2"><doi>10.5281/zenodo.1003184</doi></citation><citation key="ref3"><unstructured_citation>New York, Ebbinghaus, H., On Memory: A contribution to experimental psychology, 1913</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Manning, J. R. and Norman, K. A. and Kahana, M. J., The Cognitive Neurosciences, Fifth edition, Gazzaniga, M., 557–566, MIT Press, The role of context in episodic memory, 2015</unstructured_citation></citation><citation key="ref5"><doi>10.1037/h0045106</doi></citation><citation key="ref6"><doi>10.3758/BF03197276</doi></citation><citation key="ref7"><unstructured_citation>Kahana, M. J., Oxford University Press, Foundations of Human Memory, New York, NY, 2012</unstructured_citation></citation><citation key="ref8"><doi>10.3758/BF03212898</doi></citation><citation key="ref9"><doi>10.5281/zenodo.54844</doi></citation></citation_list>
       </journal_article>

--- a/joss.00426/10.21105.joss.00426.crossref.xml
+++ b/joss.00426/10.21105.joss.00426.crossref.xml
@@ -1,7 +1,8 @@
-<doi_batch version="4.3.7" xmlns="http://www.crossref.org/schema/4.3.7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/schema/4.3.7 http://www.crossref.org/schemas/crossref4.3.7.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.0" xsi:schemaLocation="http://www.crossref.org/schema/4.4.0 http://www.crossref.org/schemas/crossref4.4.0.xsd">
   <head>
-    <doi_batch_id>368e02db4dc6eacadfdd0c22ce4f15f3</doi_batch_id>
-    <timestamp>20171023220938</timestamp>
+    <doi_batch_id>93ae218992c4bf3b9eae7051c12b4de3</doi_batch_id>
+    <timestamp>20171024135922</timestamp>
     <depositor>
       <depositor_name>JOSS Admin</depositor_name>
       <email_address>admin@theoj.org</email_address>
@@ -42,23 +43,33 @@
         <pages>
           <first_page>426</first_page>
         </pages>
-        <program xmlns="http://www.crossref.org/relations.xsd">
-          <related_item>
-            <description>Software archive</description>
-            <inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.1012531</inter_work_relation>
-          </related_item>
-          <related_item>
-          <description>GitHub review issue</description>
-            <inter_work_relation relationship-type="hasReview" identifier-type="URI">https://github.com/openjournals/joss-reviews/issues/426</inter_work_relation>
-          </related_item>
-        </program>
         <publisher_item>
-          <item_number>10.21105/joss.00426</item_number>
+          <identifier id_type="doi">10.21105/joss.00426</identifier>
         </publisher_item>
+        <ai:program name="AccessIndicators">
+          <ai:license_ref applies_to="vor">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="am">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+          <ai:license_ref applies_to="tdm">http://creativecommons.org/licenses/by/4.0/</ai:license_ref>
+        </ai:program>
+        <rel:program>
+          <rel:related_item>
+            <rel:description>Software archive</rel:description>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.1012531</rel:inter_work_relation>
+          </rel:related_item>
+          <rel:related_item>
+            <rel:description>GitHub review issue</rel:description>
+            <rel:inter_work_relation relationship-type="hasReview" identifier-type="uri">https://github.com/openjournals/joss-reviews/issues/426</rel:inter_work_relation>
+          </rel:related_item>
+        </rel:program>
         <doi_data>
           <doi>10.21105/joss.00426</doi>
-          <timestamp>20171023220938</timestamp>
+          <timestamp>20171024135922</timestamp>
           <resource>http://joss.theoj.org/papers/10.21105/joss.00426</resource>
+          <collection property="text-mining">
+            <item>
+              <resource mime_type="application/pdf">http://www.theoj.org/joss-papers/joss.00426/10.21105.joss.00426.pdf</resource>
+            </item>
+          </collection>
         </doi_data>
         <citation_list><citation key="ref1"><doi>journal.pone.0177459</doi></citation><citation key="ref2"><unstructured_citation>singularity-hub, Singularity Hub, Sochat, Vanessa, singularity container and workflow management, \urlhttps://singularity-hub.org/, Accessed: 2017-3-29</unstructured_citation></citation><citation key="ref3"><unstructured_citation>Singularity Registry Documentation, Singularity Registry Documentation, Sochat, Vanessa, Background information and documentation for setting up a Singularity Registry, \urlhttps://singularityhub.github.io/sregistry/, Accessed: 2017-9-26</unstructured_citation></citation><citation key="ref4"><unstructured_citation>Singularity Registry Github, Singularity Registry Github, Sochat, Vanessa, open source code for setting up a Singularity Registry, \urlhttps://github.com/singularityhub/sregistry, Accessed: 2017-9-26</unstructured_citation></citation><citation key="ref5"><unstructured_citation>Virtual Machines: Versatile Platforms for Systems and Processes, Smith, J E and Nair, R, Morgan Kaufmann Publishers, The Morgan Kaufmann Series in Computer Architecture and Design Series, 2005</unstructured_citation></citation><citation key="ref6"><unstructured_citation>Docker: Lightweight Linux Containers for Consistent Development and Deployment, Merkel, Dirk, Linux J., Belltown Media, 2014, 239, mar, 2014, Houston, TX, 3</unstructured_citation></citation><citation key="ref7"><unstructured_citation>Docker-based solutions to reproducibility in science - Seven Bridges, Seven Bridges, Seven Bridges is launching a toolkit for creating fully portable bioinformatics workflows, using Docker and the Common Workflow Language., jun, 2015, \urlhttps://blog.sbgenomics.com/docker-based-solutions-to-reproducibility-in-science/, Accessed: 2016-12-17, 6</unstructured_citation></citation><citation key="ref8"><doi>https://doi.org/10.1007/978-3-319-31744-1_52</doi></citation><citation key="ref9"><doi>10.12688/f1000research.7536.1</doi></citation><citation key="ref10"><doi>10.1186/s13742-015-0087-0</doi></citation><citation key="ref11"><doi>10.1145/2723872.2723882</doi></citation><citation key="ref12"><doi>http://dx.doi.org/10.1155/2015/243180</doi></citation><citation key="ref13"><unstructured_citation>Data management to support reproducible research, Wandell, B A and Rokem, A and Perry, L M and Schaefer, G and Dougherty, R F, We describe the current state and future plans for a set of tools for scientific data management (SDM) designed to support scientific transparency and reproducible research. SDM has been in active use at our MRI Center for more than two years. We designed the system to be used from the beginning of a research project, which contrasts with conventional end-state databases that accept data as a project concludes. A number of benefits accrue from using scientific data management tools early and throughout the project, including data integrity as well as reuse of the data and of computational methods., feb, 2015, arXiv, q-bio.QM, 1502.06900, 2</unstructured_citation></citation></citation_list>
       </journal_article>


### PR DESCRIPTION
This is a fairly major update to the Crossref metadata we deposit from JOSS.

Updates include:
- [Add `AccessIndicators`](https://github.com/openjournals/joss-papers/compare/moar-crossref-fields?expand=1#diff-6da471d3809425cdf657038264056c07R49) to make it clear what license the JOSS papers are released under
- [Link to the software archive](https://github.com/openjournals/joss-papers/compare/moar-crossref-fields?expand=1#diff-6da471d3809425cdf657038264056c07R56) we require authors to create when submitting to JOSS
- [Link to the JOSS review](https://github.com/openjournals/joss-papers/compare/moar-crossref-fields?expand=1#diff-6da471d3809425cdf657038264056c07R61) on GitHub
- [Link to the PDF](https://github.com/openjournals/joss-papers/compare/moar-crossref-fields?expand=1#diff-6da471d3809425cdf657038264056c07R70) to facilitate data mining of JOSS content

/ cc @jenniferlin15 @karthik for visibility
