### PR TITLE
Add labels after successful workflow run

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -11,6 +11,10 @@ on:
       issue_id:
         description: 'The issue number of the submission'
         required: true
+      add_labels:
+        description: 'Labels to add to the issue after successful run'
+        required: false
+        default: ''
 jobs:
   acceptance-and-publishing:
     name: ${{ format('Accepting paper in issue {0}', github.event.inputs.issue_id) }}
@@ -94,6 +98,12 @@ jobs:
           3. Party like you just published a paper! 🎉🌈🦄💃👻🤘
 
           Any issues? Notify your editorial technical team..."
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_REPO: openjournals/joss-reviews
+      - name: Labeling
+        if: ${{ success() && github.event.inputs.add_labels != '' }}
+        run: gh issue edit ${{ github.event.inputs.issue_id }} --add-label ${{ github.event.inputs.add_labels }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: openjournals/joss-reviews

--- a/.github/workflows/recommend-acceptance.yml
+++ b/.github/workflows/recommend-acceptance.yml
@@ -11,6 +11,10 @@ on:
       issue_id:
         description: 'The issue number of the submission'
         required: true
+      add_labels:
+        description: 'Labels to add to the issue after successful run'
+        required: false
+        default: ''
 jobs:
   preparing-for-acceptance:
     name: ${{ format('Prepare paper acceptance in issue {0}', github.event.inputs.issue_id) }}
@@ -61,6 +65,12 @@ jobs:
           Check final proof :point_right: ${{ steps.open-pr.outputs.pr_url}}
 
           If the paper PDF and the deposit XML files look good in ${{ steps.open-pr.outputs.pr_url}}, then you can now move forward with accepting the submission by compiling again with the command \`@editorialbot accept\`"
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_REPO: openjournals/joss-reviews
+      - name: Labeling
+        if: ${{ success() && github.event.inputs.add_labels != '' }}
+        run: gh issue edit ${{ github.event.inputs.issue_id }} --add-label ${{ github.event.inputs.add_labels }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: openjournals/joss-reviews


### PR DESCRIPTION
This PR allows the `recommend-acceptance` and `accept` workflows to add labels to the issue only after running succesfully.