### PR TITLE
Fixing math markup in 10.21105.joss.00558.jats

### DIFF
--- a/joss.00558/10.21105.joss.00558.jats
+++ b/joss.00558/10.21105.joss.00558.jats
@@ -24,22 +24,34 @@ method on distributed-memory architectures</article-title>
 <contrib-group>
 <contrib contrib-type="author">
 <contrib-id contrib-id-type="orcid">0000-0001-6330-2709</contrib-id>
-<string-name>Pi-Yueh Chuang</string-name>
+<name>
+<surname>Chuang</surname>
+<given-names>Pi-Yueh</given-names>
+</name>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
 <contrib contrib-type="author">
 <contrib-id contrib-id-type="orcid">0000-0001-5335-7853</contrib-id>
-<string-name>Olivier Mesnard</string-name>
+<name>
+<surname>Mesnard</surname>
+<given-names>Olivier</given-names>
+</name>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
 <contrib contrib-type="author">
 <contrib-id contrib-id-type="orcid">0000-0001-6409-7022</contrib-id>
-<string-name>Anush Krishnan</string-name>
+<name>
+<surname>Krishnan</surname>
+<given-names>Anush</given-names>
+</name>
 <xref ref-type="aff" rid="aff-2"/>
 </contrib>
 <contrib contrib-type="author">
 <contrib-id contrib-id-type="orcid">0000-0001-5812-2711</contrib-id>
-<string-name>Lorena A. Barba</string-name>
+<name>
+<surname>Barba</surname>
+<given-names>Lorena A.</given-names>
+</name>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
 <aff id="aff-1">
@@ -298,12 +310,13 @@ a Creative Commons Attribution 4.0 International License (CC BY
     \right)]]></tex-math>
     <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>A</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:msub><mml:mi>Q</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:msub><mml:mi>Q</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>λ</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>with</p>
-    <p>t[ G, H ] ;
-    (</p>
-    <p>) ;
-    r_1 r^n + bc_1 ;
-    r_2 (</p>
-    <p>) \end{equation*}</p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[Q_1 \equiv \left[ \begin{matrix} D \\ E \end{matrix} \right] ;\
+    Q_2 \equiv \left[ G, H \right] ;\
+    \lambda \equiv \left( \begin{matrix} \phi \\ \tilde{f} \end{matrix} \right) ;\
+    r_1 \equiv r^n + bc_1 ;\
+    r_2 \equiv \left( \begin{matrix} bc_2 \\ u_B^{n+1} \end{matrix} \right)]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:msub><mml:mi>Q</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>D</mml:mi></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>E</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:msub><mml:mi>Q</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mi>G</mml:mi><mml:mo>,</mml:mo><mml:mi>H</mml:mi><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:mi>λ</mml:mi><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>ϕ</mml:mi></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo>≡</mml:mo><mml:msup><mml:mi>r</mml:mi><mml:mi>n</mml:mi></mml:msup><mml:mo>+</mml:mo><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:msubsup><mml:mi>u</mml:mi><mml:mi>B</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msubsup></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>In practice, we never form the full system. Instead, we apply a
     block-LU decomposition as follows:</p>
     <p><disp-formula><alternatives>
@@ -354,7 +367,13 @@ a Creative Commons Attribution 4.0 International License (CC BY
     <mml:math display="inline" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>λ</mml:mi></mml:math></alternatives></inline-formula>,
     to enforce the divergence-free condition and the no-slip constraint
     at the location of the immersed boundary. The sequence is:</p>
-    <p></p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[\begin{aligned}
+    & A u^* = r_1 \\
+    & Q_1A^{-1}Q_2 \lambda = Q_1 u^* - r_2 \\
+    & u^{n+1} = u^* - A^{-1}Q_1 \lambda
+    \end{aligned}]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mtable><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:mi>A</mml:mi><mml:msup><mml:mi>u</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>=</mml:mo><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:msub><mml:mi>Q</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:msub><mml:mi>Q</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mi>λ</mml:mi><mml:mo>=</mml:mo><mml:msub><mml:mi>Q</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:msup><mml:mi>u</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>−</mml:mo><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mo>=</mml:mo><mml:msup><mml:mi>u</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>−</mml:mo><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:msub><mml:mi>Q</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mi>λ</mml:mi></mml:mtd></mml:mtr></mml:mtable></mml:math></alternatives></disp-formula></p>
     <p>The IBPM implemented in PetIBM solves, at every time step,
     Equations (5) to (6). (Note: the inverse of the implicit operator
     <inline-formula><alternatives>
@@ -436,12 +455,17 @@ a Creative Commons Attribution 4.0 International License (CC BY
     \right)]]></tex-math>
     <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>γ</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>ϕ</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>where</p>
-    <p>;
-    {D} \end{equation*}</p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[\bar{A} \equiv \left[ \begin{matrix} A & H \\ E & 0 \end{matrix} \right] ;\
+    \bar{G} \equiv \left[ \begin{matrix} G \\ 0 \end{matrix} \right] ;\
+    \bar{D} \equiv \left[ \begin{matrix} D & 0 \end{matrix} \right]]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>A</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mi>H</mml:mi></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>E</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>G</mml:mi></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>D</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>and</p>
-    <p>v (</p>
-    <p>) ;
-    {r_2} bc_2 \end{equation*}</p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[\gamma^{n+1} \equiv \left( \begin{matrix} u^{n+1} \\ \tilde{f} \end{matrix}\right) ;\
+    \bar{r_1} \equiv \left( \begin{matrix} r_n + bc_1 \\ u_B^{n+1} \end{matrix}\right) ;\
+    \bar{r_2} \equiv bc_2]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:msup><mml:mi>γ</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mo>≡</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msub><mml:mi>r</mml:mi><mml:mi>n</mml:mi></mml:msub><mml:mo>+</mml:mo><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:msubsup><mml:mi>u</mml:mi><mml:mi>B</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msubsup></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>;</mml:mo><mml:mspace width="0.222em"></mml:mspace><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mo>≡</mml:mo><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>2</mml:mn></mml:msub></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>Two successive block-LU decompositions are applied to decouple
     the Lagrangian forces <inline-formula><alternatives>
     <tex-math><![CDATA[\tilde{f}]]></tex-math>
@@ -495,7 +519,13 @@ a Creative Commons Attribution 4.0 International License (CC BY
     \right)]]></tex-math>
     <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mo>−</mml:mo><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:msup><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>I</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:msup><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd><mml:mtd columnalign="center"><mml:mi>I</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>γ</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>ϕ</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd><mml:mtd columnalign="center"><mml:mo>−</mml:mo><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:msup><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>γ</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>ϕ</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>which leads to the following sequence of operations:</p>
-    <p></p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[\begin{aligned}
+    & \bar{A} \gamma^* = \bar{r_1} \\
+    & \bar{D}\bar{A}^{-1}\bar{G} \phi = \bar{D} \gamma^* - \bar{r_2} \\
+    & \gamma^{n+1} = \gamma^* - \bar{A}^{-1}\bar{G} \phi
+    \end{aligned}]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mtable><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:msup><mml:mi>γ</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>=</mml:mo><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>1</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:msup><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mi>ϕ</mml:mi><mml:mo>=</mml:mo><mml:mover><mml:mi>D</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:msup><mml:mi>γ</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>−</mml:mo><mml:mover><mml:msub><mml:mi>r</mml:mi><mml:mn>2</mml:mn></mml:msub><mml:mo accent="true">‾</mml:mo></mml:mover></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:msup><mml:mi>γ</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mo>=</mml:mo><mml:msup><mml:mi>γ</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>−</mml:mo><mml:msup><mml:mover><mml:mi>A</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mover><mml:mi>G</mml:mi><mml:mo accent="true">‾</mml:mo></mml:mover><mml:mi>ϕ</mml:mi></mml:mtd></mml:mtr></mml:mtable></mml:math></alternatives></disp-formula></p>
     <p>A second block-LU decomposition is applied to the first equation
     above:</p>
     <p><disp-formula><alternatives>
@@ -539,7 +569,13 @@ a Creative Commons Attribution 4.0 International License (CC BY
     \right)]]></tex-math>
     <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>A</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>E</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mo>−</mml:mo><mml:mi>E</mml:mi><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mi>H</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>I</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mi>H</mml:mi></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd><mml:mtd columnalign="center"><mml:mi>I</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>u</mml:mi><mml:mo>*</mml:mo></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">[</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:mi>A</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mn>0</mml:mn></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mi>E</mml:mi></mml:mtd><mml:mtd columnalign="center"><mml:mo>−</mml:mo><mml:mi>E</mml:mi><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mi>H</mml:mi></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">]</mml:mo></mml:mrow><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mo>*</mml:mo><mml:mo>*</mml:mo></mml:mrow></mml:msup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow><mml:mo>=</mml:mo><mml:mrow><mml:mo stretchy="true" form="prefix">(</mml:mo><mml:mtable><mml:mtr><mml:mtd columnalign="center"><mml:msup><mml:mi>r</mml:mi><mml:mi>n</mml:mi></mml:msup><mml:mo>+</mml:mo><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="center"><mml:msubsup><mml:mi>u</mml:mi><mml:mi>B</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msubsup></mml:mtd></mml:mtr></mml:mtable><mml:mo stretchy="true" form="postfix">)</mml:mo></mml:mrow></mml:mrow></mml:math></alternatives></disp-formula></p>
     <p>and we end up with the following sequence:</p>
-    <p></p>
+    <p><disp-formula><alternatives>
+    <tex-math><![CDATA[\begin{aligned}
+    & A u^{* *} = r^n + bc_1 \\
+    & EA^{-1}H \tilde{f} = E u^{* *} - u_B^{n+1} \\
+    & u^* = u^{* *} - A^{-1}H \tilde{f}
+    \end{aligned}]]></tex-math>
+    <mml:math display="block" xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mtable><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:mi>A</mml:mi><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mo>*</mml:mo><mml:mo>*</mml:mo></mml:mrow></mml:msup><mml:mo>=</mml:mo><mml:msup><mml:mi>r</mml:mi><mml:mi>n</mml:mi></mml:msup><mml:mo>+</mml:mo><mml:mi>b</mml:mi><mml:msub><mml:mi>c</mml:mi><mml:mn>1</mml:mn></mml:msub></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:mi>E</mml:mi><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mi>H</mml:mi><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover><mml:mo>=</mml:mo><mml:mi>E</mml:mi><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mo>*</mml:mo><mml:mo>*</mml:mo></mml:mrow></mml:msup><mml:mo>−</mml:mo><mml:msubsup><mml:mi>u</mml:mi><mml:mi>B</mml:mi><mml:mrow><mml:mi>n</mml:mi><mml:mo>+</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msubsup></mml:mtd></mml:mtr><mml:mtr><mml:mtd columnalign="right"></mml:mtd><mml:mtd columnalign="left"><mml:msup><mml:mi>u</mml:mi><mml:mo>*</mml:mo></mml:msup><mml:mo>=</mml:mo><mml:msup><mml:mi>u</mml:mi><mml:mrow><mml:mo>*</mml:mo><mml:mo>*</mml:mo></mml:mrow></mml:msup><mml:mo>−</mml:mo><mml:msup><mml:mi>A</mml:mi><mml:mrow><mml:mo>−</mml:mo><mml:mn>1</mml:mn></mml:mrow></mml:msup><mml:mi>H</mml:mi><mml:mover><mml:mi>f</mml:mi><mml:mo accent="true">̃</mml:mo></mml:mover></mml:mtd></mml:mtr></mml:mtable></mml:math></alternatives></disp-formula></p>
     <p>The decoupled version of the IBPM implemented in PetIBM solves,
     at every time step, Equations (15) to (17) followed by Equations
     (12) and (13).</p>


### PR DESCRIPTION
The Markdown sources contained blank lines in the math equations, which had led to a faulty conversion.