### PR TITLE
Fixing markup in 10.21105.joss.03742.jats

### DIFF
--- a/joss.03742/10.21105.joss.03742.jats
+++ b/joss.03742/10.21105.joss.03742.jats
@@ -46,7 +46,7 @@ Package</article-title>
 </name>
 <xref ref-type="aff" rid="aff-1"/>
 </contrib>
-<contrib contrib-type="author">
+<contrib contrib-type="author" corresp="yes">
 <contrib-id contrib-id-type="orcid">0000-0002-1772-0376</contrib-id>
 <name>
 <surname>Abukhdeir</surname>
@@ -167,12 +167,9 @@ a Creative Commons Attribution 4.0 International License (CC BY
   element-based open-source simulation software. Many of the most
   widely-used computational multiphysics software packages, such as
   COMSOL Multiphysics
-  (<xref alt="COMSOL Multiphysics \textsuperscript{\textregistered}, n.d." rid="ref-comsol" ref-type="bibr"><italic>COMSOL
-  Multiphysics
-  <inline-formula><tex-math><![CDATA[\textsuperscript{\textregistered}]]></tex-math></inline-formula></italic>,
-  n.d.</xref>) or ANSYS Fluent
-  (<xref alt="Ansys \textsuperscript{\textregistered} Fluent, n.d." rid="ref-fluent" ref-type="bibr"><italic>Ansys
-  <inline-formula><tex-math><![CDATA[\textsuperscript{\textregistered}]]></tex-math></inline-formula>
+  (<xref alt="COMSOL Multiphysics®, n.d." rid="ref-comsol" ref-type="bibr"><italic>COMSOL
+  Multiphysics®</italic>, n.d.</xref>) or ANSYS Fluent
+  (<xref alt="Ansys® Fluent, n.d." rid="ref-fluent" ref-type="bibr"><italic>Ansys®
   Fluent</italic>, n.d.</xref>), are closed-source and cost-prohibitive.
   Furthermore, the predominance of the finite volume method for fluid
   dynamics simulations inherently limits simulation accuracy for a given
@@ -441,7 +438,6 @@ a Creative Commons Attribution 4.0 International License (CC BY
   problem, two-dimensional transient multi-component incompressible flow
   around a set of immersed circular objects within a rectangular
   channel, shown below.</p>
-  <p><named-content content-type="image"></named-content></p>
   <p>The mixture is composed of two components (A, B) where A undergoes
   an irreversible reaction A → B. A parabolic inlet flow of pure A is
   imposed, such that the mixture undergoes convection, reaction, and
@@ -773,7 +769,7 @@ a Creative Commons Attribution 4.0 International License (CC BY
   </ref>
   <ref id="ref-comsol">
     <element-citation>
-      <article-title>COMSOL Multiphysics \textsuperscript{\textregistered}</article-title>
+      <article-title>COMSOL Multiphysics®</article-title>
       <publisher-name>COMSOL AB; Online</publisher-name>
       <publisher-loc>Stockholm, Sweden</publisher-loc>
       <date-in-citation content-type="access-date"><year iso-8601-date="2022-04-21">2022</year><month>04</month><day>21</day></date-in-citation>
@@ -782,7 +778,7 @@ a Creative Commons Attribution 4.0 International License (CC BY
   </ref>
   <ref id="ref-fluent">
     <element-citation>
-      <article-title>Ansys \textsuperscript{\textregistered} Fluent</article-title>
+      <article-title>Ansys® Fluent</article-title>
       <publisher-name>ANSYS Inc. Online</publisher-name>
       <date-in-citation content-type="access-date"><year iso-8601-date="2022-04-21">2022</year><month>04</month><day>21</day></date-in-citation>
       <uri>https://www.ansys.com/products/fluids/ansys-fluent</uri>


### PR DESCRIPTION
Markup created by a missing image is removed (confirmed with the author). Furthermore, citations containing ® are fixed.