### PR TITLE
Checkout only the embeddings

### DIFF
--- a/.github/workflows/draft-paper.yml
+++ b/.github/workflows/draft-paper.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Checkout code
         if: ${{ steps.generate-files.outcome == 'success' && startsWith(github.event.inputs.issue_title, '[PRE REVIEW]') }}
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            embeddings.csv.gz
+          sparse-checkout-cone-mode: false
       - name: Find most similar paper
         if: ${{ steps.generate-files.outcome == 'success' && startsWith(github.event.inputs.issue_title, '[PRE REVIEW]') }}
         id: find-similar-papers


### PR DESCRIPTION
The find-similar-papers script [only needs](https://github.com/openjournals/find-similar-papers/blob/main/find-similar-papers.py#L170-L229) the embeddings, so there's no need to download all the papers here.