### PR TITLE
Update accept.yml to add sleep step

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -76,6 +76,9 @@ jobs:
           journal_secret: ${{ secrets.JOSS_SECRET }}
           issue_id: ${{ github.event.inputs.issue_id }}
           paper_path: ${{ steps.generate-files.outputs.paper_file_path}}
+      - name: Sleep for 300 seconds
+        run: sleep 300
+        shell: bash
       - name: Citation.cff file info
         uses: xuanxu/citation-file-action@main
         with:


### PR DESCRIPTION
We want to introduce a delay between registering the DOIs with Crossref, uploading papers to GitHub, and notifying the world (either in the JOSS review thread or Mastadon) about the paper being accepted.

This PR introduces an additional step to the accept workflow to make the job sleep for 5 minutes.