### PR TITLE
#1324: Fix archive DOIs

### DIFF
--- a/joss.00041/10.21105.joss.00041.crossref.xml
+++ b/joss.00041/10.21105.joss.00041.crossref.xml
@@ -54,7 +54,7 @@
         <rel:program>
           <rel:related_item>
             <rel:description>Software archive</rel:description>
-            <rel:inter_work_relation relationship-type="references" identifier-type="doi">http://dx.doi.org/10.5281/zenodo.23671</rel:inter_work_relation>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.61965</rel:inter_work_relation>
           </rel:related_item>
           <rel:related_item>
             <rel:description>GitHub review issue</rel:description>

--- a/joss.04684/10.21105.joss.04684.crossref.xml
+++ b/joss.04684/10.21105.joss.04684.crossref.xml
@@ -96,7 +96,7 @@ Statistical Transformations</title>
         <rel:program>
           <rel:related_item>
             <rel:description>Software archive</rel:description>
-            <rel:inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.714</rel:inter_work_relation>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.7143971</rel:inter_work_relation>
           </rel:related_item>
           <rel:related_item>
             <rel:description>GitHub review issue</rel:description>

--- a/joss.05883/10.21105.joss.05883.crossref.xml
+++ b/joss.05883/10.21105.joss.05883.crossref.xml
@@ -79,7 +79,7 @@ Australian Energy Market Operator</title>
         <rel:program>
           <rel:related_item>
             <rel:description>Software archive</rel:description>
-            <rel:inter_work_relation relationship-type="references" identifier-type="doi">v1.0.7</rel:inter_work_relation>
+            <rel:inter_work_relation relationship-type="references" identifier-type="doi">10.5281/zenodo.10162614</rel:inter_work_relation>
           </rel:related_item>
           <rel:related_item>
             <rel:description>GitHub review issue</rel:description>


### PR DESCRIPTION
After searching a bit, I've found the only instances of the bad archive DOIs mentioned in https://github.com/openjournals/joss/issues/1324 and fixed them in the Crossref XML.

Please let me know if this is the right place to do this, or point me to a better place for this.